### PR TITLE
Add development task outline and documentation scaffolding

### DIFF
--- a/changelog_2025-08-18.md
+++ b/changelog_2025-08-18.md
@@ -1,0 +1,7 @@
+# Changelog v0.1.0
+
+## 2025-08-18
+- Added initial development tasks outline.
+- Initialized user manual skeleton.
+- Created first changelog entry.
+

--- a/development_tasks_2025-08-18.md
+++ b/development_tasks_2025-08-18.md
@@ -1,0 +1,27 @@
+# Development Tasks v0.1.0
+
+Date: 2025-08-18
+
+## Core Services
+- [ ] Implement `api-gateway` (FastAPI) with authentication and RBAC.
+- [ ] Build `orchestrator` to schedule daily and intraday jobs.
+- [ ] Develop `data-ingestion` service for market connectors and OHLCV normalization.
+- [ ] Create `strategy-engine` for signal generation and allocation targets.
+- [ ] Design `risk-engine` handling risk budgets, VaR/ES limits, and stop levels.
+- [ ] Implement `execution-engine` for order generation and broker aggregation.
+- [ ] Provide `backtester` for reproducible simulations and reports.
+- [ ] Build `ui` using Next.js/React/Tailwind for dashboards and actions.
+- [ ] Set up `db` schema using Postgres and Timescale; configure Redis for caching.
+- [ ] Integrate message bus (NATS or RabbitMQ) for events and logs.
+
+## Observability
+- [ ] Standardize structured logging and expose Prometheus metrics.
+- [ ] Configure OpenTelemetry traces and Grafana dashboards.
+
+## Data Model
+- [ ] Implement tables for users, goals, accounts, portfolios, positions, orders, executions, prices, signals, actions, risk_limits, metrics_daily, and backtests.
+
+## Documentation
+- [ ] Expand `user_manual` with installation, usage, and architecture details.
+- [ ] Maintain `changelog` for every update with version and date.
+

--- a/user_manual_2025-08-18.md
+++ b/user_manual_2025-08-18.md
@@ -1,0 +1,18 @@
+# User Manual v0.1.0
+
+Date: 2025-08-18
+
+This document will evolve into a comprehensive encyclopedia for the project.
+
+## Overview
+- Goal-based investment platform with daily actionable recommendations.
+
+## Installation
+- Pending implementation.
+
+## Usage
+- Pending implementation.
+
+## Architecture
+- See README for initial specification.
+


### PR DESCRIPTION
## Summary
- outline core development tasks for each service and module
- add initial user manual skeleton for future documentation
- create dated changelog file tracking repository updates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3aa3c64cc832c896d635e5e142f72