### PR TITLE
Add environment setup scripts and requirements

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.2.0
+# Changelog v0.3.0
 
 ## 2025-08-18
 - Added initial development tasks outline.
@@ -7,3 +7,6 @@
 - Scaffolded service directories with versioned bootstraps and scripts.
 - Added .gitignore for build artifacts and volatile paths.
 - Expanded user manual with service overview.
+- Added requirements.txt with runtime and development dependencies.
+- Introduced setup_env and remove_env scripts for Linux/Mac and Windows.
+- Documented installer usage in user manuals.

--- a/changelog_2025-08-18.md
+++ b/changelog_2025-08-18.md
@@ -1,4 +1,4 @@
-# Changelog v0.2.0
+# Changelog v0.3.0
 
 ## 2025-08-18
 - Added initial development tasks outline.
@@ -8,3 +8,6 @@
 - Scaffolded service directories with versioned bootstraps and scripts.
 - Added .gitignore for build artifacts and volatile paths.
 - Expanded user manual with service overview.
+- Added requirements.txt with runtime and development dependencies.
+- Introduced setup_env and remove_env scripts for Linux/Mac and Windows.
+- Documented installer usage in user manuals.

--- a/remove_env.cmd
+++ b/remove_env.cmd
@@ -1,0 +1,4 @@
+@echo off
+rem remove_env.cmd v0.1.0
+
+pip uninstall -r "%~dp0requirements.txt" -y

--- a/remove_env.sh
+++ b/remove_env.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# remove_env.sh v0.1.0
+
+set -e
+
+pip uninstall -r "$(dirname "$0")/requirements.txt" -y

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+# requirements.txt v0.1.0
+
+# Runtime dependencies
+requests>=2.31.0
+
+# Development dependencies
+pytest>=8.2.0

--- a/setup_env.cmd
+++ b/setup_env.cmd
@@ -1,0 +1,4 @@
+@echo off
+rem setup_env.cmd v0.1.0
+
+pip install -r "%~dp0requirements.txt"

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# setup_env.sh v0.1.0
+
+set -e
+
+pip install -r "$(dirname "$0")/requirements.txt"

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.2.0
+# User Manual v0.3.0
 
 Date: 2025-08-18
 
@@ -19,6 +19,8 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - db
 
 ## Installation
+- Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies.
+- Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
 - Each service includes install.sh and remove.sh scripts (v0.2.0).
 
 ## Architecture

--- a/user_manual_2025-08-18.md
+++ b/user_manual_2025-08-18.md
@@ -1,4 +1,4 @@
-# User Manual v0.2.0
+# User Manual v0.3.0
 
 Date: 2025-08-18
 
@@ -8,7 +8,8 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Goal-based investment platform with daily actionable recommendations.
 
 ## Installation
-- Pending implementation.
+- Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies.
+- Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
 
 ## Usage
 - Pending implementation.


### PR DESCRIPTION
## Summary
- add minimal requirements.txt
- provide setup_env and remove_env scripts for Unix and Windows
- document installation steps in user manuals

## Testing
- `bash setup_env.sh`
- `bash remove_env.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a3ade1f3dc832c9a6704109ac93554