### PR TITLE
Add database migrations and schema tooling

### DIFF
--- a/admin/db_check.php
+++ b/admin/db_check.php
@@ -1,0 +1,32 @@
+<?php
+// db_check.php v0.1.0
+$expectedVersion = 'v0.1.0';
+$dsn = sprintf('pgsql:host=%s;port=%s;dbname=%s',
+    getenv('DB_HOST') ?: 'localhost',
+    getenv('DB_PORT') ?: '5432',
+    getenv('DB_NAME') ?: 'cashmachiine');
+$user = getenv('DB_USER') ?: 'postgres';
+$pass = getenv('DB_PASS') ?: '';
+$requiredTables = [
+    'users','goals','accounts','portfolios','positions','orders',
+    'executions','prices','signals','actions','risk_limits','metrics_daily','backtests'
+];
+try {
+    $pdo = new PDO($dsn, $user, $pass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+} catch (Exception $e) {
+    echo "Connection failed: {$e->getMessage()}\n";
+    exit(1);
+}
+foreach ($requiredTables as $tbl) {
+    $stmt = $pdo->query("SELECT to_regclass('public.$tbl')");
+    if (!$stmt->fetchColumn()) {
+        echo "Missing table: $tbl\n";
+        exit(1);
+    }
+}
+$schemaVersion = getenv('DB_SCHEMA_VERSION') ?: 'unknown';
+if ($schemaVersion !== $expectedVersion) {
+    echo "Schema version mismatch: expected $expectedVersion, got $schemaVersion\n";
+    exit(1);
+}
+echo "Database connection and schema ok.\n";

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.3.0
+# Changelog v0.4.0
 
 ## 2025-08-18
 - Added initial development tasks outline.
@@ -10,3 +10,7 @@
 - Added requirements.txt with runtime and development dependencies.
 - Introduced setup_env and remove_env scripts for Linux/Mac and Windows.
 - Documented installer usage in user manuals.
+- Added initial database schema migrations.
+- Introduced admin/db_check.php for schema validation.
+- Added install_db.sh and remove_db.sh scripts.
+- Documented database setup in user manuals.

--- a/changelog_2025-08-18.md
+++ b/changelog_2025-08-18.md
@@ -1,4 +1,4 @@
-# Changelog v0.3.0
+# Changelog v0.4.0
 
 ## 2025-08-18
 - Added initial development tasks outline.
@@ -11,3 +11,7 @@
 - Added requirements.txt with runtime and development dependencies.
 - Introduced setup_env and remove_env scripts for Linux/Mac and Windows.
 - Documented installer usage in user manuals.
+- Added initial database schema migrations.
+- Introduced admin/db_check.php for schema validation.
+- Added install_db.sh and remove_db.sh scripts.
+- Documented database setup in user manuals.

--- a/db/migrations/001_create_users.sql
+++ b/db/migrations/001_create_users.sql
@@ -1,0 +1,9 @@
+-- users table migration v0.1.0
+CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    email TEXT NOT NULL,
+    tz TEXT NOT NULL,
+    kyc_level TEXT,
+    risk_profile TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/db/migrations/002_create_goals.sql
+++ b/db/migrations/002_create_goals.sql
@@ -1,0 +1,12 @@
+-- goals table migration v0.1.0
+CREATE TABLE IF NOT EXISTS goals (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id),
+    name TEXT NOT NULL,
+    start_capital NUMERIC,
+    target_amount NUMERIC,
+    deadline DATE,
+    feasibility_score NUMERIC,
+    risk_bounds JSONB,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/db/migrations/003_create_accounts.sql
+++ b/db/migrations/003_create_accounts.sql
@@ -1,0 +1,9 @@
+-- accounts table migration v0.1.0
+CREATE TABLE IF NOT EXISTS accounts (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id),
+    broker TEXT NOT NULL,
+    base_ccy TEXT,
+    margin_allowed BOOLEAN,
+    fees_model TEXT
+);

--- a/db/migrations/004_create_portfolios.sql
+++ b/db/migrations/004_create_portfolios.sql
@@ -1,0 +1,7 @@
+-- portfolios table migration v0.1.0
+CREATE TABLE IF NOT EXISTS portfolios (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id),
+    goal_id INTEGER REFERENCES goals(id),
+    name TEXT NOT NULL
+);

--- a/db/migrations/005_create_positions.sql
+++ b/db/migrations/005_create_positions.sql
@@ -1,0 +1,11 @@
+-- positions table migration v0.1.0
+CREATE TABLE IF NOT EXISTS positions (
+    id SERIAL PRIMARY KEY,
+    portfolio_id INTEGER REFERENCES portfolios(id),
+    symbol TEXT NOT NULL,
+    venue TEXT,
+    qty NUMERIC,
+    avg_price NUMERIC,
+    leverage NUMERIC,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/db/migrations/006_create_orders.sql
+++ b/db/migrations/006_create_orders.sql
@@ -1,0 +1,15 @@
+-- orders table migration v0.1.0
+CREATE TABLE IF NOT EXISTS orders (
+    id SERIAL PRIMARY KEY,
+    account_id INTEGER REFERENCES accounts(id),
+    symbol TEXT NOT NULL,
+    side TEXT,
+    qty NUMERIC,
+    type TEXT,
+    limit_price NUMERIC,
+    status TEXT,
+    reason TEXT,
+    sl NUMERIC,
+    tp NUMERIC,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/db/migrations/007_create_executions.sql
+++ b/db/migrations/007_create_executions.sql
@@ -1,0 +1,9 @@
+-- executions table migration v0.1.0
+CREATE TABLE IF NOT EXISTS executions (
+    id SERIAL PRIMARY KEY,
+    order_id INTEGER REFERENCES orders(id),
+    price NUMERIC,
+    qty NUMERIC,
+    fee NUMERIC,
+    ts TIMESTAMPTZ
+);

--- a/db/migrations/008_create_prices.sql
+++ b/db/migrations/008_create_prices.sql
@@ -1,0 +1,12 @@
+-- prices table migration v0.1.0
+CREATE TABLE IF NOT EXISTS prices (
+    symbol TEXT NOT NULL,
+    venue TEXT NOT NULL,
+    ts TIMESTAMPTZ NOT NULL,
+    o NUMERIC,
+    h NUMERIC,
+    l NUMERIC,
+    c NUMERIC,
+    v NUMERIC,
+    PRIMARY KEY(symbol, venue, ts)
+);

--- a/db/migrations/009_create_signals.sql
+++ b/db/migrations/009_create_signals.sql
@@ -1,0 +1,10 @@
+-- signals table migration v0.1.0
+CREATE TABLE IF NOT EXISTS signals (
+    id SERIAL PRIMARY KEY,
+    symbol TEXT NOT NULL,
+    kind TEXT,
+    value NUMERIC,
+    horizon TEXT,
+    confidence NUMERIC,
+    ts TIMESTAMPTZ
+);

--- a/db/migrations/010_create_actions.sql
+++ b/db/migrations/010_create_actions.sql
@@ -1,0 +1,10 @@
+-- actions table migration v0.1.0
+CREATE TABLE IF NOT EXISTS actions (
+    id SERIAL PRIMARY KEY,
+    goal_id INTEGER REFERENCES goals(id),
+    day DATE,
+    title TEXT NOT NULL,
+    details_json JSONB,
+    status TEXT CHECK (status IN ('pending','done','ignored')),
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/db/migrations/011_create_risk_limits.sql
+++ b/db/migrations/011_create_risk_limits.sql
@@ -1,0 +1,9 @@
+-- risk_limits table migration v0.1.0
+CREATE TABLE IF NOT EXISTS risk_limits (
+    id SERIAL PRIMARY KEY,
+    portfolio_id INTEGER REFERENCES portfolios(id),
+    max_dd NUMERIC,
+    max_var NUMERIC,
+    vol_target NUMERIC,
+    kelly_cap NUMERIC
+);

--- a/db/migrations/012_create_metrics_daily.sql
+++ b/db/migrations/012_create_metrics_daily.sql
@@ -1,0 +1,12 @@
+-- metrics_daily table migration v0.1.0
+CREATE TABLE IF NOT EXISTS metrics_daily (
+    date DATE,
+    portfolio_id INTEGER REFERENCES portfolios(id),
+    nav NUMERIC,
+    ret NUMERIC,
+    vol NUMERIC,
+    dd NUMERIC,
+    var95 NUMERIC,
+    es97 NUMERIC,
+    PRIMARY KEY(date, portfolio_id)
+);

--- a/db/migrations/013_create_backtests.sql
+++ b/db/migrations/013_create_backtests.sql
@@ -1,0 +1,9 @@
+-- backtests table migration v0.1.0
+CREATE TABLE IF NOT EXISTS backtests (
+    id SERIAL PRIMARY KEY,
+    cfg_json JSONB,
+    start DATE,
+    end DATE,
+    kpis_json JSONB,
+    report_path TEXT
+);

--- a/install_db.sh
+++ b/install_db.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# install_db.sh v0.1.0
+set -e
+for file in db/migrations/*.sql; do
+  echo "Applying $file"
+  psql "$@" -f "$file"
+done

--- a/remove_db.sh
+++ b/remove_db.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# remove_db.sh v0.1.0
+set -e
+TABLES=(actions backtests metrics_daily risk_limits signals prices executions orders positions portfolios accounts goals users)
+for tbl in "${TABLES[@]}"; do
+  echo "Dropping $tbl"
+  psql "$@" -c "DROP TABLE IF EXISTS $tbl CASCADE;"
+done

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.3.0
+# User Manual v0.4.0
 
 Date: 2025-08-18
 
@@ -22,6 +22,11 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
 - Each service includes install.sh and remove.sh scripts (v0.2.0).
+
+## Database Setup
+- Run `./install_db.sh` to create tables.
+- Run `./remove_db.sh` to drop tables.
+- Verify with `php admin/db_check.php`.
 
 ## Architecture
 - See README for initial specification.

--- a/user_manual_2025-08-18.md
+++ b/user_manual_2025-08-18.md
@@ -1,4 +1,4 @@
-# User Manual v0.3.0
+# User Manual v0.4.0
 
 Date: 2025-08-18
 
@@ -10,6 +10,11 @@ This document will evolve into a comprehensive encyclopedia for the project.
 ## Installation
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
+
+## Database Setup
+- Run `./install_db.sh` to create tables.
+- Run `./remove_db.sh` to drop tables.
+- Verify with `php admin/db_check.php`.
 
 ## Usage
 - Pending implementation.


### PR DESCRIPTION
## Summary
- add SQL migrations for core tables
- provide db_check.php script to validate schema
- add install_db.sh and remove_db.sh helpers

## Testing
- `pytest`
- `php admin/db_check.php` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a3af10f08c832c9d45b74b8563082a