### PR TITLE
feat: add FastAPI gateway with JWT auth

### DIFF
--- a/api-gateway/install.sh
+++ b/api-gateway/install.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-# api-gateway installer v0.2.0
-echo "Installing api-gateway service..."
+# api-gateway installer v0.2.1
+echo "Installing api-gateway service dependencies..."
+

--- a/api-gateway/main.py
+++ b/api-gateway/main.py
@@ -1,0 +1,45 @@
+"""FastAPI app exposing goals and actions endpoints with JWT auth v0.2.0"""
+from fastapi import FastAPI, Depends, HTTPException, status, Request
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from jose import JWTError, jwt
+
+SECRET_KEY = "secret"
+ALGORITHM = "HS256"
+
+security = HTTPBearer()
+
+app = FastAPI()
+
+
+@app.middleware("http")
+async def add_version_header(request: Request, call_next):
+    response = await call_next(request)
+    response.headers["X-API-Version"] = "v0.2.0"
+    return response
+
+
+def verify_token(credentials: HTTPAuthorizationCredentials = Depends(security), required_role: str | None = None):
+    try:
+        payload = jwt.decode(credentials.credentials, SECRET_KEY, algorithms=[ALGORITHM])
+    except JWTError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    role = payload.get("role")
+    if required_role and role != required_role:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Insufficient role")
+    return payload
+
+
+def role_checker(role: str):
+    def checker(credentials: HTTPAuthorizationCredentials = Depends(security)):
+        return verify_token(credentials, role)
+    return checker
+
+
+@app.get("/goals")
+def get_goals(_: dict = Depends(role_checker("user"))):
+    return {"goals": []}
+
+
+@app.get("/actions")
+def get_actions(_: dict = Depends(role_checker("admin"))):
+    return {"actions": []}

--- a/api-gateway/remove.sh
+++ b/api-gateway/remove.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-# api-gateway removal v0.2.0
+# api-gateway removal v0.2.1
 echo "Removing api-gateway service..."
+

--- a/api-gateway/tests/test_main.py
+++ b/api-gateway/tests/test_main.py
@@ -1,0 +1,43 @@
+"""Unit tests for api-gateway main application v0.2.0"""
+from fastapi.testclient import TestClient
+from jose import jwt
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "main.py"
+SPEC = importlib.util.spec_from_file_location("api_gateway_main", MODULE_PATH)
+main = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(main)
+
+SECRET_KEY = main.SECRET_KEY
+ALGORITHM = main.ALGORITHM
+
+client = TestClient(main.app)
+
+
+def create_token(role: str):
+    return jwt.encode({"role": role}, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def test_goals_requires_auth():
+    response = client.get("/goals")
+    assert response.status_code == 403
+
+
+def test_goals_returns_version_header_and_data():
+    token = create_token("user")
+    response = client.get("/goals", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+    assert response.headers["X-API-Version"] == "v0.2.0"
+    assert response.json() == {"goals": []}
+
+
+def test_actions_requires_admin_role():
+    token = create_token("user")
+    response = client.get("/actions", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 403
+
+    admin_token = create_token("admin")
+    response = client.get("/actions", headers={"Authorization": f"Bearer {admin_token}"})
+    assert response.status_code == 200
+    assert response.json() == {"actions": []}

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.4.0
+# Changelog v0.5.0
 
 ## 2025-08-18
 - Added initial development tasks outline.
@@ -14,3 +14,4 @@
 - Introduced admin/db_check.php for schema validation.
 - Added install_db.sh and remove_db.sh scripts.
 - Documented database setup in user manuals.
+- Added FastAPI API gateway with JWT auth, role checks, version header, install scripts, tests, and updated requirements.

--- a/changelog_2025-08-18.md
+++ b/changelog_2025-08-18.md
@@ -1,4 +1,4 @@
-# Changelog v0.4.0
+# Changelog v0.5.0
 
 ## 2025-08-18
 - Added initial development tasks outline.
@@ -15,3 +15,4 @@
 - Introduced admin/db_check.php for schema validation.
 - Added install_db.sh and remove_db.sh scripts.
 - Documented database setup in user manuals.
+- Added FastAPI API gateway with JWT auth, role checks, version header, install scripts, tests, and updated requirements.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
-# requirements.txt v0.1.0
+# requirements.txt v0.2.1
 
 # Runtime dependencies
 requests>=2.31.0
+fastapi>=0.110.0
+uvicorn>=0.29.0
+python-jose[cryptography]>=3.3.0
 
 # Development dependencies
 pytest>=8.2.0
+httpx>=0.27.0

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.4.0
+# User Manual v0.5.0
 
 Date: 2025-08-18
 
@@ -21,12 +21,17 @@ This document will evolve into a comprehensive encyclopedia for the project.
 ## Installation
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
-- Each service includes install.sh and remove.sh scripts (v0.2.0).
+- Each service includes install.sh and remove.sh scripts (v0.2.1).
 
 ## Database Setup
 - Run `./install_db.sh` to create tables.
 - Run `./remove_db.sh` to drop tables.
 - Verify with `php admin/db_check.php`.
+
+## API Gateway
+- FastAPI service exposing `/goals` for users and `/actions` for admins.
+- Authenticate requests with JWT tokens containing a `role` claim.
+- All responses include header `X-API-Version: v0.2.0`.
 
 ## Architecture
 - See README for initial specification.

--- a/user_manual_2025-08-18.md
+++ b/user_manual_2025-08-18.md
@@ -1,4 +1,4 @@
-# User Manual v0.4.0
+# User Manual v0.5.0
 
 Date: 2025-08-18
 
@@ -10,6 +10,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 ## Installation
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
+- Each service includes install.sh and remove.sh scripts (v0.2.1).
 
 ## Database Setup
 - Run `./install_db.sh` to create tables.
@@ -17,11 +18,12 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Verify with `php admin/db_check.php`.
 
 ## Usage
-- Pending implementation.
+- API Gateway exposes `/goals` (user role) and `/actions` (admin role).
+- Send JWT tokens with a `role` claim in the `Authorization` header.
+- Responses include header `X-API-Version: v0.2.0`.
 
 ## Architecture
 - See README for initial specification.
-
 
 ## Services Overview
 - api-gateway


### PR DESCRIPTION
## Summary
- scaffold FastAPI API gateway with JWT auth and role-based endpoints
- add install/remove scripts, tests, and documentation
- update requirements and changelogs

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3b044237c832c826631df08aef560