### PR TITLE
Add daily APScheduler orchestrator with logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ db/data/
 
 # Misc
 .DS_Store
+orchestrator/logs/

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.5.0
+# Changelog v0.5.1
 
 ## 2025-08-18
 - Added initial development tasks outline.
@@ -15,3 +15,8 @@
 - Added install_db.sh and remove_db.sh scripts.
 - Documented database setup in user manuals.
 - Added FastAPI API gateway with JWT auth, role checks, version header, install scripts, tests, and updated requirements.
+- Introduced orchestrator scheduler with APScheduler for daily 08:00 Europe/Paris jobs and configurable logging.
+- Added log creation scripts for orchestrator logs.
+- Updated user manual with scheduling details.
+- Added APScheduler dependency to requirements.
+- Updated orchestrator install/remove scripts to v0.3.0.

--- a/changelog_2025-08-18.md
+++ b/changelog_2025-08-18.md
@@ -1,4 +1,4 @@
-# Changelog v0.5.0
+# Changelog v0.5.1
 
 ## 2025-08-18
 - Added initial development tasks outline.
@@ -16,3 +16,8 @@
 - Added install_db.sh and remove_db.sh scripts.
 - Documented database setup in user manuals.
 - Added FastAPI API gateway with JWT auth, role checks, version header, install scripts, tests, and updated requirements.
+- Introduced orchestrator scheduler with APScheduler for daily 08:00 Europe/Paris jobs and configurable logging.
+- Added log creation scripts for orchestrator logs.
+- Updated user manual with scheduling details.
+- Added APScheduler dependency to requirements.
+- Updated orchestrator install/remove scripts to v0.3.0.

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -1,2 +1,2 @@
-"""orchestrator service v0.2.0"""
-__version__ = "0.2.0"
+"""orchestrator service v0.3.0"""
+__version__ = "0.3.0"

--- a/orchestrator/install.sh
+++ b/orchestrator/install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-# orchestrator installer v0.2.0
+# orchestrator installer v0.3.0
 echo "Installing orchestrator service..."

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""orchestrator scheduler v0.3.0"""
+import argparse
+import logging
+import os
+import subprocess
+import time
+from logging.handlers import RotatingFileHandler
+from zoneinfo import ZoneInfo
+from apscheduler.schedulers.background import BackgroundScheduler
+
+LOG_DEFAULT = os.environ.get("ORCHESTRATOR_LOG", "orchestrator/logs/orchestrator.log")
+
+
+def sample_job():
+    logging.info("Orchestrator job executed")
+
+
+def install_service():
+    script_path = os.path.join(os.path.dirname(__file__), "install.sh")
+    subprocess.run([script_path], check=True)
+
+
+def remove_service():
+    script_path = os.path.join(os.path.dirname(__file__), "remove.sh")
+    subprocess.run([script_path], check=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Orchestrator controller v0.3.0")
+    parser.add_argument("--install", action="store_true", help="Install orchestrator service")
+    parser.add_argument("--remove", action="store_true", help="Remove orchestrator service")
+    parser.add_argument("--log-path", default=LOG_DEFAULT, help="Path to log file")
+    args = parser.parse_args()
+
+    if args.install:
+        install_service()
+        return
+    if args.remove:
+        remove_service()
+        return
+
+    log_path = args.log_path
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+    logging.basicConfig(level=logging.INFO,
+                        handlers=[RotatingFileHandler(log_path, maxBytes=1_000_000, backupCount=3),
+                                  logging.StreamHandler()],
+                        format="%(asctime)s %(levelname)s %(message)s")
+
+    scheduler = BackgroundScheduler(timezone=ZoneInfo("Europe/Paris"))
+    scheduler.add_job(sample_job, "cron", hour=8, minute=0)
+    scheduler.start()
+    logging.info("Scheduler started, waiting for jobs")
+    try:
+        while True:
+            time.sleep(1)
+    except (KeyboardInterrupt, SystemExit):
+        scheduler.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/orchestrator/remove.sh
+++ b/orchestrator/remove.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-# orchestrator removal v0.2.0
+# orchestrator removal v0.3.0
 echo "Removing orchestrator service..."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
-# requirements.txt v0.2.1
+# requirements.txt v0.2.2
 
 # Runtime dependencies
 requests>=2.31.0
 fastapi>=0.110.0
 uvicorn>=0.29.0
 python-jose[cryptography]>=3.3.0
+apscheduler>=3.10.4
 
 # Development dependencies
 pytest>=8.2.0

--- a/tools/log_create.sh
+++ b/tools/log_create.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# log directory creator v0.1.0
+set -e
+mkdir -p orchestrator/logs

--- a/tools/log_create_win.cmd
+++ b/tools/log_create_win.cmd
@@ -1,0 +1,3 @@
+@echo off
+REM log directory creator v0.1.0
+mkdir orchestrator\logs 2>nul

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.5.0
+# User Manual v0.5.1
 
 Date: 2025-08-18
 
@@ -32,6 +32,12 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - FastAPI service exposing `/goals` for users and `/actions` for admins.
 - Authenticate requests with JWT tokens containing a `role` claim.
 - All responses include header `X-API-Version: v0.2.0`.
+
+## Orchestrator
+- Uses APScheduler to trigger daily jobs at 08:00 Europe/Paris.
+- Start with `python orchestrator/main.py`.
+- Flags: `--install` to install, `--remove` to uninstall, `--log-path` to customize log file.
+- Default log file `orchestrator/logs/orchestrator.log`.
 
 ## Architecture
 - See README for initial specification.

--- a/user_manual_2025-08-18.md
+++ b/user_manual_2025-08-18.md
@@ -1,4 +1,4 @@
-# User Manual v0.5.0
+# User Manual v0.5.1
 
 Date: 2025-08-18
 
@@ -21,6 +21,12 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - API Gateway exposes `/goals` (user role) and `/actions` (admin role).
 - Send JWT tokens with a `role` claim in the `Authorization` header.
 - Responses include header `X-API-Version: v0.2.0`.
+
+## Orchestrator
+- Uses APScheduler to trigger daily jobs at 08:00 Europe/Paris.
+- Start with `python orchestrator/main.py`.
+- Flags: `--install`, `--remove`, `--log-path`.
+- Default log file `orchestrator/logs/orchestrator.log`.
 
 ## Architecture
 - See README for initial specification.


### PR DESCRIPTION
## Summary
- schedule orchestrator jobs daily at 08:00 Europe/Paris with configurable logging
- add log creation scripts for orchestrator
- document scheduling and update changelog, installers, and requirements

## Testing
- `pip install -r requirements.txt`
- `bash tools/log_create.sh`
- `python orchestrator/main.py --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3b2a3d804832ca00778a07ceda1fc