### PR TITLE
Ajout d’une interface de stratégie et exemples core/satellite

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.5.2
+# Changelog v0.5.3
 
 ## 2025-08-18
 - Added initial development tasks outline.
@@ -25,3 +25,7 @@
 - Extended log creation scripts and .gitignore for data-ingestion logs.
 - Enhanced admin/db_check.php to validate `prices` table columns.
 - Expanded user manual with data-ingestion fetcher usage.
+- Added base Strategy interface with `signals()` and `target_weights()` methods.
+- Introduced example `CoreStrategy` and `SatelliteStrategy` with unit-test stubs.
+- Updated strategy-engine install/remove scripts to v0.3.0.
+- Bumped requirements.txt to v0.2.4.

--- a/changelog_2025-08-18.md
+++ b/changelog_2025-08-18.md
@@ -1,4 +1,4 @@
-# Changelog v0.5.2
+# Changelog v0.5.3
 
 ## 2025-08-18
 - Added initial development tasks outline.
@@ -26,3 +26,7 @@
 - Extended log creation scripts and .gitignore for data-ingestion logs.
 - Enhanced admin/db_check.php to validate `prices` table columns.
 - Expanded user manual with data-ingestion fetcher usage.
+- Added base Strategy interface with `signals()` and `target_weights()` methods.
+- Introduced example `CoreStrategy` and `SatelliteStrategy` with unit-test stubs.
+- Updated strategy-engine install/remove scripts to v0.3.0.
+- Bumped requirements.txt to v0.2.4.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# requirements.txt v0.2.3
+# requirements.txt v0.2.4
 
 # Runtime dependencies
 requests>=2.31.0

--- a/strategy-engine/__init__.py
+++ b/strategy-engine/__init__.py
@@ -1,2 +1,4 @@
-"""strategy-engine service v0.2.0"""
-__version__ = "0.2.0"
+"""strategy-engine service v0.3.0"""
+__version__ = "0.3.0"
+
+from .interface import Strategy

--- a/strategy-engine/install.sh
+++ b/strategy-engine/install.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-# strategy-engine installer v0.2.0
+# strategy-engine installer v0.3.0
+
 echo "Installing strategy-engine service..."

--- a/strategy-engine/interface.py
+++ b/strategy-engine/interface.py
@@ -1,0 +1,18 @@
+"""Strategy interface for strategy-engine v0.1.0 (2025-08-18)"""
+from abc import ABC, abstractmethod
+
+__version__ = "0.1.0"
+
+
+class Strategy(ABC):
+    """Base strategy interface defining signals and target weights methods."""
+
+    @abstractmethod
+    def signals(self, market_data):
+        """Return trading signals based on market data."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def target_weights(self, signals):
+        """Return target portfolio weights based on signals."""
+        raise NotImplementedError

--- a/strategy-engine/remove.sh
+++ b/strategy-engine/remove.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-# strategy-engine removal v0.2.0
+# strategy-engine removal v0.3.0
+
 echo "Removing strategy-engine service..."

--- a/strategy-engine/strategies/__init__.py
+++ b/strategy-engine/strategies/__init__.py
@@ -1,0 +1,2 @@
+"""Example strategies package v0.1.0 (2025-08-18)"""
+__version__ = "0.1.0"

--- a/strategy-engine/strategies/core.py
+++ b/strategy-engine/strategies/core.py
@@ -1,0 +1,14 @@
+"""Core strategy example v0.1.0 (2025-08-18)"""
+from ..interface import Strategy
+
+__version__ = "0.1.0"
+
+
+class CoreStrategy(Strategy):
+    """Long-term core allocation example."""
+
+    def signals(self, market_data):
+        return {"SPY": 1.0}
+
+    def target_weights(self, signals):
+        return {"SPY": 1.0}

--- a/strategy-engine/strategies/satellite.py
+++ b/strategy-engine/strategies/satellite.py
@@ -1,0 +1,14 @@
+"""Satellite strategy example v0.1.0 (2025-08-18)"""
+from ..interface import Strategy
+
+__version__ = "0.1.0"
+
+
+class SatelliteStrategy(Strategy):
+    """Tactical satellite allocation example."""
+
+    def signals(self, market_data):
+        return {"BTC": 0.5}
+
+    def target_weights(self, signals):
+        return {"BTC": 0.1}

--- a/strategy-engine/tests/__init__.py
+++ b/strategy-engine/tests/__init__.py
@@ -1,0 +1,2 @@
+"""strategy-engine tests package v0.1.0 (2025-08-18)"""
+__version__ = "0.1.0"

--- a/strategy-engine/tests/test_interface.py
+++ b/strategy-engine/tests/test_interface.py
@@ -1,0 +1,37 @@
+"""Unit test stubs for strategy interface v0.1.0 (2025-08-18)"""
+import importlib.util
+import sys
+from pathlib import Path
+
+__version__ = "0.1.0"
+
+ENGINE_DIR = Path(__file__).resolve().parents[1]
+
+
+def load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+interface = load("strategy_engine.interface", ENGINE_DIR / "interface.py")
+core = load("strategy_engine.strategies.core", ENGINE_DIR / "strategies/core.py")
+satellite = load("strategy_engine.strategies.satellite", ENGINE_DIR / "strategies/satellite.py")
+
+
+def test_core_strategy_interface():
+    strategy = core.CoreStrategy()
+    sigs = strategy.signals({})
+    weights = strategy.target_weights(sigs)
+    assert isinstance(sigs, dict)
+    assert isinstance(weights, dict)
+
+
+def test_satellite_strategy_interface():
+    strategy = satellite.SatelliteStrategy()
+    sigs = strategy.signals({})
+    weights = strategy.target_weights(sigs)
+    assert isinstance(sigs, dict)
+    assert isinstance(weights, dict)

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.5.2
+# User Manual v0.5.3
 
 Date: 2025-08-18
 
@@ -45,6 +45,10 @@ This document will evolve into a comprehensive encyclopedia for the project.
   - `from data_ingestion.fetchers.equities_yahoo import YahooEquityFetcher`
   - `YahooEquityFetcher().save(YahooEquityFetcher().fetch("AAPL"))`
 - Logs stored in `data-ingestion/logs`.
+
+## Strategy Engine
+- Base `Strategy` interface exposing `signals()` and `target_weights()`.
+- Example implementations: `CoreStrategy` and `SatelliteStrategy`.
 
 ## Architecture
 - See README for initial specification.

--- a/user_manual_2025-08-18.md
+++ b/user_manual_2025-08-18.md
@@ -1,4 +1,4 @@
-# User Manual v0.5.2
+# User Manual v0.5.3
 
 Date: 2025-08-18
 
@@ -34,6 +34,10 @@ This document will evolve into a comprehensive encyclopedia for the project.
   - `from data_ingestion.fetchers.equities_yahoo import YahooEquityFetcher`
   - `YahooEquityFetcher().save(YahooEquityFetcher().fetch("AAPL"))`
 - Logs stored in `data-ingestion/logs`.
+
+## Strategy Engine
+- Base `Strategy` interface exposing `signals()` and `target_weights()`.
+- Example implementations: `CoreStrategy` and `SatelliteStrategy`.
 
 ## Architecture
 - See README for initial specification.


### PR DESCRIPTION
## Résumé
- Création d’une interface `Strategy` avec méthodes `signals()` et `target_weights()`.
- Ajout d’exemples `CoreStrategy` et `SatelliteStrategy` accompagnés de tests unitaires.
- Mise à jour des scripts d’installation/suppression, de la documentation et des dépendances.

## Tests
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3b5edb0bc832c8de32ce5af04022e