### PR TITLE
feat: add risk engine service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ db/data/
 .DS_Store
 orchestrator/logs/
 data-ingestion/logs/
+risk-engine/logs/

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.5.3
+# Changelog v0.5.4
 
 ## 2025-08-18
 - Added initial development tasks outline.
@@ -29,3 +29,8 @@
 - Introduced example `CoreStrategy` and `SatelliteStrategy` with unit-test stubs.
 - Updated strategy-engine install/remove scripts to v0.3.0.
 - Bumped requirements.txt to v0.2.4.
+- Implemented risk-engine utilities for volatility targeting, VaR/ES limits, and Kelly caps with REST endpoint.
+- Added strategy-engine client for risk service and tests for risk calculations.
+- Updated risk-engine install/remove scripts to v0.3.0 and added log directories with script updates.
+- Added numpy dependency and bumped requirements to v0.2.5.
+- Expanded user manual with risk-engine usage and bumped to v0.5.4.

--- a/changelog_2025-08-18.md
+++ b/changelog_2025-08-18.md
@@ -1,4 +1,4 @@
-# Changelog v0.5.3
+# Changelog v0.5.4
 
 ## 2025-08-18
 - Added initial development tasks outline.
@@ -30,3 +30,8 @@
 - Introduced example `CoreStrategy` and `SatelliteStrategy` with unit-test stubs.
 - Updated strategy-engine install/remove scripts to v0.3.0.
 - Bumped requirements.txt to v0.2.4.
+- Implemented risk-engine utilities for volatility targeting, VaR/ES limits, and Kelly caps with REST endpoint.
+- Added strategy-engine client for risk service and tests for risk calculations.
+- Updated risk-engine install/remove scripts to v0.3.0 and added log directories with script updates.
+- Added numpy dependency and bumped requirements to v0.2.5.
+- Expanded user manual with risk-engine usage and bumped to v0.5.4.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# requirements.txt v0.2.4
+# requirements.txt v0.2.5
 
 # Runtime dependencies
 requests>=2.31.0
@@ -9,6 +9,7 @@ apscheduler>=3.10.4
 yfinance>=0.2.40
 ccxt>=4.0.0
 psycopg2-binary>=2.9.9
+numpy>=1.26.0
 
 # Development dependencies
 pytest>=8.2.0

--- a/risk-engine/__init__.py
+++ b/risk-engine/__init__.py
@@ -1,2 +1,4 @@
-"""risk-engine service v0.2.0"""
-__version__ = "0.2.0"
+"""risk-engine service v0.3.0 (2025-08-18)"""
+__version__ = "0.3.0"
+
+from .engine import volatility_target, var_es, kelly_fraction

--- a/risk-engine/api.py
+++ b/risk-engine/api.py
@@ -1,0 +1,47 @@
+"""FastAPI endpoint for risk adjustments v0.3.0 (2025-08-18)"""
+from __future__ import annotations
+
+__version__ = "0.3.0"
+
+from typing import List
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+try:  # local import when executed as module
+    from .engine import volatility_target, var_es, kelly_fraction
+except Exception:  # fallback for direct execution
+    from engine import volatility_target, var_es, kelly_fraction
+
+
+class RiskRequest(BaseModel):
+    weights: List[float]
+    returns: List[float]
+    current_vol: float
+    target_vol: float
+    var_limit: float
+    es_limit: float
+    confidence: float = 0.95
+    edge: float
+    variance: float
+    kelly_cap: float
+
+
+class RiskResponse(BaseModel):
+    adjusted_weights: List[float]
+    var: float
+    es: float
+    kelly_fraction: float
+
+
+app = FastAPI(title="risk-engine", version=__version__)
+
+
+@app.post("/adjust", response_model=RiskResponse)
+def adjust(payload: RiskRequest) -> RiskResponse:
+    adjusted = volatility_target(payload.weights, payload.current_vol, payload.target_vol)
+    var, es = var_es(payload.returns, payload.confidence)
+    kelly = kelly_fraction(payload.edge, payload.variance, payload.kelly_cap)
+    if var > payload.var_limit or es > payload.es_limit:
+        adjusted = [0.0 for _ in adjusted]
+    return RiskResponse(adjusted_weights=adjusted, var=var, es=es, kelly_fraction=kelly)

--- a/risk-engine/engine.py
+++ b/risk-engine/engine.py
@@ -1,0 +1,35 @@
+"""Risk calculation utilities v0.3.0 (2025-08-18)"""
+from __future__ import annotations
+
+__version__ = "0.3.0"
+
+from typing import Iterable, List, Tuple
+
+
+def volatility_target(weights: Iterable[float], current_vol: float, target_vol: float) -> List[float]:
+    """Scale weights to meet target volatility."""
+    if current_vol <= 0:
+        return list(weights)
+    scale = target_vol / current_vol
+    return [w * scale for w in weights]
+
+
+def var_es(returns: Iterable[float], confidence: float = 0.95) -> Tuple[float, float]:
+    """Return Value-at-Risk and Expected Shortfall for given returns."""
+    data = sorted(returns)
+    n = len(data)
+    if n == 0 or not 0 < confidence < 1:
+        return 0.0, 0.0
+    index = max(int((1 - confidence) * n) - 1, 0)
+    var = abs(data[index])
+    tail = [abs(r) for r in data[: index + 1]]
+    es = sum(tail) / len(tail) if tail else var
+    return var, es
+
+
+def kelly_fraction(edge: float, variance: float, cap: float) -> float:
+    """Return Kelly optimal fraction capped at `cap`."""
+    if variance <= 0:
+        return 0.0
+    kelly = edge / variance
+    return max(0.0, min(kelly, cap))

--- a/risk-engine/install.sh
+++ b/risk-engine/install.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
-# risk-engine installer v0.2.0
+# risk-engine installer v0.3.0 (2025-08-18)
+set -e
+
 echo "Installing risk-engine service..."
+mkdir -p logs

--- a/risk-engine/remove.sh
+++ b/risk-engine/remove.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
-# risk-engine removal v0.2.0
+# risk-engine removal v0.3.0 (2025-08-18)
+set -e
+
 echo "Removing risk-engine service..."
+rm -rf logs

--- a/risk-engine/tests/test_engine.py
+++ b/risk-engine/tests/test_engine.py
@@ -1,0 +1,37 @@
+"""Tests for risk calculations v0.3.0 (2025-08-18)"""
+import importlib.util
+import sys
+from pathlib import Path
+
+__version__ = "0.3.0"
+
+ENGINE_DIR = Path(__file__).resolve().parents[1]
+
+
+def load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+engine = load("risk_engine.engine", ENGINE_DIR / "engine.py")
+
+
+def test_volatility_target():
+    weights = [0.5, 0.5]
+    adjusted = engine.volatility_target(weights, 0.1, 0.2)
+    assert adjusted == [1.0, 1.0]
+
+
+def test_var_es():
+    returns = [-0.1, -0.05, 0.02, -0.2, 0.03]
+    var, es = engine.var_es(returns, 0.8)
+    assert var > 0
+    assert es >= var
+
+
+def test_kelly_fraction():
+    frac = engine.kelly_fraction(0.1, 0.2, 0.5)
+    assert frac == 0.5

--- a/strategy-engine/__init__.py
+++ b/strategy-engine/__init__.py
@@ -1,4 +1,5 @@
-"""strategy-engine service v0.3.0"""
-__version__ = "0.3.0"
+"""strategy-engine service v0.3.1 (2025-08-18)"""
+__version__ = "0.3.1"
 
 from .interface import Strategy
+from .risk_client import adjust_risk

--- a/strategy-engine/risk_client.py
+++ b/strategy-engine/risk_client.py
@@ -1,0 +1,35 @@
+"""Risk-engine REST client v0.1.0 (2025-08-18)"""
+import requests
+
+__version__ = "0.1.0"
+
+
+def adjust_risk(
+    weights,
+    returns,
+    current_vol,
+    target_vol,
+    var_limit,
+    es_limit,
+    confidence,
+    edge,
+    variance,
+    kelly_cap,
+    url="http://localhost:8000"
+):
+    """Call risk-engine `/adjust` endpoint and return JSON response."""
+    payload = {
+        "weights": list(weights),
+        "returns": list(returns),
+        "current_vol": current_vol,
+        "target_vol": target_vol,
+        "var_limit": var_limit,
+        "es_limit": es_limit,
+        "confidence": confidence,
+        "edge": edge,
+        "variance": variance,
+        "kelly_cap": kelly_cap,
+    }
+    resp = requests.post(f"{url}/adjust", json=payload, timeout=5)
+    resp.raise_for_status()
+    return resp.json()

--- a/strategy-engine/tests/__init__.py
+++ b/strategy-engine/tests/__init__.py
@@ -1,2 +1,0 @@
-"""strategy-engine tests package v0.1.0 (2025-08-18)"""
-__version__ = "0.1.0"

--- a/tools/log_create.sh
+++ b/tools/log_create.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# log directory creator v0.2.0
+# log directory creator v0.3.0
 set -e
 mkdir -p orchestrator/logs
 mkdir -p data-ingestion/logs
+mkdir -p risk-engine/logs

--- a/tools/log_create_win.cmd
+++ b/tools/log_create_win.cmd
@@ -1,4 +1,5 @@
 @echo off
-REM log directory creator v0.2.0
+REM log directory creator v0.3.0
 mkdir orchestrator\logs 2>nul
 mkdir data-ingestion\logs 2>nul
+mkdir risk-engine\logs 2>nul

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.5.3
+# User Manual v0.5.4
 
 Date: 2025-08-18
 
@@ -21,7 +21,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 ## Installation
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
-- Each service includes install.sh and remove.sh scripts (v0.2.1).
+- Each service includes install.sh and remove.sh scripts (v0.3.0).
 
 ## Database Setup
 - Run `./install_db.sh` to create tables.
@@ -49,6 +49,11 @@ This document will evolve into a comprehensive encyclopedia for the project.
 ## Strategy Engine
 - Base `Strategy` interface exposing `signals()` and `target_weights()`.
 - Example implementations: `CoreStrategy` and `SatelliteStrategy`.
+
+## Risk Engine
+- Provides volatility targeting, Value-at-Risk/Expected Shortfall checks, and Kelly fraction caps.
+- REST endpoint `/adjust` consumed by `strategy-engine` via `risk_client`.
+- Logs stored in `risk-engine/logs`.
 
 ## Architecture
 - See README for initial specification.

--- a/user_manual_2025-08-18.md
+++ b/user_manual_2025-08-18.md
@@ -1,4 +1,4 @@
-# User Manual v0.5.3
+# User Manual v0.5.4
 
 Date: 2025-08-18
 
@@ -10,7 +10,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 ## Installation
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
-- Each service includes install.sh and remove.sh scripts (v0.2.1).
+- Each service includes install.sh and remove.sh scripts (v0.3.0).
 
 ## Database Setup
 - Run `./install_db.sh` to create tables.
@@ -38,6 +38,11 @@ This document will evolve into a comprehensive encyclopedia for the project.
 ## Strategy Engine
 - Base `Strategy` interface exposing `signals()` and `target_weights()`.
 - Example implementations: `CoreStrategy` and `SatelliteStrategy`.
+
+## Risk Engine
+- Provides volatility targeting, Value-at-Risk/Expected Shortfall checks, and Kelly fraction caps.
+- REST endpoint `/adjust` consumed by `strategy-engine` via `risk_client`.
+- Logs stored in `risk-engine/logs`.
 
 ## Architecture
 - See README for initial specification.


### PR DESCRIPTION
## Summary
- implement risk engine utilities for volatility targeting, VaR/ES and Kelly caps
- expose `/adjust` FastAPI endpoint and client in strategy-engine
- document and configure logging for new risk engine service

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3b7bd30e8832cabbf447a076be5b6