### PR TITLE
chore: add ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+# ci.yml v0.1.0
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Lint
+        run: python -m compileall .
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest
+
+  build:
+    runs-on: ubuntu-latest
+    needs: test
+    strategy:
+      matrix:
+        service: [api-gateway, orchestrator, data-ingestion, strategy-engine, risk-engine, execution-engine, backtester, ui]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build service image
+        run: |
+          if [ -f "${{ matrix.service }}/Dockerfile" ]; then
+            docker build -t ${{ matrix.service }} ${{ matrix.service }}
+          else
+            echo "No Dockerfile for ${{ matrix.service }}, skipping."
+          fi

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# Goal-Based Investment Copilot — Spécification fonctionnelle v0.1.1
+# Goal-Based Investment Copilot — Spécification fonctionnelle v0.1.2
 
-*Date : 2025-02-14*
+[![Lint](https://github.com/OpenAI/CashMachiine/actions/workflows/ci.yml/badge.svg?branch=main&job=lint)](https://github.com/OpenAI/CashMachiine/actions/workflows/ci.yml?query=branch%3Amain)
+[![Tests](https://github.com/OpenAI/CashMachiine/actions/workflows/ci.yml/badge.svg?branch=main&job=test)](https://github.com/OpenAI/CashMachiine/actions/workflows/ci.yml?query=branch%3Amain)
+[![Build](https://github.com/OpenAI/CashMachiine/actions/workflows/ci.yml/badge.svg?branch=main&job=build)](https://github.com/OpenAI/CashMachiine/actions/workflows/ci.yml?query=branch%3Amain)
 
-Consultez le [manuel utilisateur](user_manual_2025-02-14.md) pour l'installation, l'utilisation, l'architecture et le dépannage.
+*Date : 2025-08-19*
+
+Consultez le [manuel utilisateur](user_manual_2025-08-19.md) pour l'installation, l'utilisation, l'architecture et le dépannage.
 
 ## 1) Vision & cas d’usage
 
@@ -69,7 +73,7 @@ Construire un logiciel qui, à partir d’un **capital initial**, d’un **objec
 
 ## 6) Architecture technique
 
-Voir aussi la section [Architecture](user_manual_2025-02-14.md#architecture) du manuel utilisateur.
+Voir aussi la section [Architecture](user_manual_2025-08-19.md#architecture) du manuel utilisateur.
 
 **Monorepo** avec services conteneurisés (Docker) :
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.0
+# Changelog v0.6.1
 
 ## 2025-02-14
 - Introduced user manual revision with installation, usage, architecture and troubleshooting sections.
@@ -14,6 +14,9 @@
 - Added Prometheus and OpenTelemetry dependencies.
 - Initialized Next.js UI with Tailwind pages for goal creation and daily actions referencing api-gateway.
 - Removed binary UI screenshots and ignored image assets to comply with repository policy.
+- Introduced GitHub Actions workflow running lint, tests and service image builds.
+- Added CI status badges to README.
+- Documented CI usage in user manuals.
 
 ## 2025-08-18
 - Added initial development tasks outline.

--- a/changelog_2025-08-19.md
+++ b/changelog_2025-08-19.md
@@ -1,4 +1,4 @@
-# Changelog v0.5.9
+# Changelog v0.6.0
 
 ## 2025-08-19
 - Added shared monitoring utilities providing JSON logging, Prometheus metrics and OpenTelemetry traces.
@@ -9,6 +9,9 @@
 - Added Prometheus and OpenTelemetry dependencies.
 - Initialized Next.js UI with Tailwind pages for goal creation and daily actions referencing api-gateway.
 - Removed binary UI screenshots and ignored image assets to comply with repository policy.
+- Introduced GitHub Actions workflow running lint, tests and service image builds.
+- Added CI status badges to README.
+- Documented CI usage in user manuals.
 
 ## 2025-08-18
 - Added initial development tasks outline.

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,6 +1,6 @@
-# User Manual v0.6.0
+# User Manual v0.6.1
 
-Date: 2025-02-14
+Date: 2025-08-19
 
 This document will evolve into a comprehensive encyclopedia for the project.
 
@@ -17,6 +17,10 @@ This document will evolve into a comprehensive encyclopedia for the project.
 ## Architecture
 - Services communicate via structured logs, metrics, and traces.
 - Review the [README](README.md#6-architecture-technique) for the full technical specification.
+
+## Continuous Integration
+- The `ci.yml` workflow runs lint, tests and builds service images on each push or pull request.
+- Badges in the README display the latest status for `lint`, `test` and `build` jobs.
 
 ## Troubleshooting
 - If dependencies are missing, rerun `./setup_env.sh`.

--- a/user_manual_2025-08-19.md
+++ b/user_manual_2025-08-19.md
@@ -1,4 +1,4 @@
-# User Manual v0.5.9
+# User Manual v0.6.0
 
 Date: 2025-08-19
 
@@ -32,6 +32,10 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Shared JSON logging writes to `logs/` with optional remote sink via `REMOTE_LOG_URL`.
 - Prometheus metrics exposed per service on configurable `METRICS_PORT`.
 - OpenTelemetry traces exported to console for debugging.
+
+## Continuous Integration
+- GitHub Actions `ci.yml` workflow runs lint, tests and builds service images.
+- Status badges in the README show the latest pipeline results.
 
 ## API Gateway
 - FastAPI service exposing `/goals` for users and `/actions` for admins.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for lint, tests, and service image builds
- expose job badges in README
- document CI usage in user manual

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4556a6770832cb66fdd69ae7da141