### PR TITLE
feat: add centralized configuration loader

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# .env.example v0.1.0 (2025-08-19)
+SECRET_KEY=change_me
+REMOTE_LOG_URL=
+API_GATEWAY_METRICS_PORT=9001
+RISK_ENGINE_METRICS_PORT=9002
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=cashmachiine
+DB_USER=postgres
+DB_PASS=
+RISK_ENGINE_URL=http://localhost:8000

--- a/api-gateway/main.py
+++ b/api-gateway/main.py
@@ -1,20 +1,20 @@
-"""FastAPI app exposing goals and actions endpoints with JWT auth v0.2.1 (2025-08-19)"""
+"""FastAPI app exposing goals and actions endpoints with JWT auth v0.2.2 (2025-08-19)"""
 from fastapi import FastAPI, Depends, HTTPException, status, Request
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from jose import JWTError, jwt
-import os
 
 from common.monitoring import setup_logging, setup_metrics, setup_tracer
+from config import settings
 
-SECRET_KEY = "secret"
+SECRET_KEY = settings.secret_key
 ALGORITHM = "HS256"
 
 security = HTTPBearer()
 
 app = FastAPI()
 
-logger = setup_logging("api-gateway", remote_url=os.environ.get("REMOTE_LOG_URL"))
-REQUEST_COUNT = setup_metrics("api-gateway", port=int(os.environ.get("METRICS_PORT", "9001")))
+logger = setup_logging("api-gateway", remote_url=settings.remote_log_url)
+REQUEST_COUNT = setup_metrics("api-gateway", port=settings.api_gateway_metrics_port)
 tracer = setup_tracer("api-gateway")
 
 
@@ -23,7 +23,7 @@ async def add_version_header(request: Request, call_next):
     with tracer.start_as_current_span(request.url.path):
         response = await call_next(request)
     REQUEST_COUNT.inc()
-    response.headers["X-API-Version"] = "v0.2.1"
+    response.headers["X-API-Version"] = "v0.2.2"
     return response
 
 

--- a/api-gateway/tests/test_main.py
+++ b/api-gateway/tests/test_main.py
@@ -1,4 +1,4 @@
-"""Unit tests for api-gateway main application v0.2.1 (2025-08-19)"""
+"""Unit tests for api-gateway main application v0.2.2 (2025-08-19)"""
 from fastapi.testclient import TestClient
 from jose import jwt
 import importlib.util
@@ -32,7 +32,7 @@ def test_goals_returns_version_header_and_data():
     token = create_token("user")
     response = client.get("/goals", headers={"Authorization": f"Bearer {token}"})
     assert response.status_code == 200
-    assert response.headers["X-API-Version"] == "v0.2.1"
+    assert response.headers["X-API-Version"] == "v0.2.2"
     assert response.json() == {"goals": []}
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.1
+# Changelog v0.6.2
 
 ## 2025-02-14
 - Introduced user manual revision with installation, usage, architecture and troubleshooting sections.
@@ -17,6 +17,10 @@
 - Introduced GitHub Actions workflow running lint, tests and service image builds.
 - Added CI status badges to README.
 - Documented CI usage in user manuals.
+- Introduced centralized configuration package loading `.env` files and environment variables.
+- Added `.env.example` and referenced it in environment setup scripts.
+- Updated services to consume `config` values instead of hard-coded constants.
+- Added `python-dotenv` dependency.
 
 ## 2025-08-18
 - Added initial development tasks outline.

--- a/changelog_2025-08-19.md
+++ b/changelog_2025-08-19.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.0
+# Changelog v0.6.1
 
 ## 2025-08-19
 - Added shared monitoring utilities providing JSON logging, Prometheus metrics and OpenTelemetry traces.
@@ -12,6 +12,10 @@
 - Introduced GitHub Actions workflow running lint, tests and service image builds.
 - Added CI status badges to README.
 - Documented CI usage in user manuals.
+- Introduced centralized configuration package loading `.env` files and environment variables.
+- Added `.env.example` and referenced it in environment setup scripts.
+- Updated services to consume `config` values instead of hard-coded constants.
+- Added `python-dotenv` dependency.
 
 ## 2025-08-18
 - Added initial development tasks outline.

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,22 @@
+"""Configuration loader v0.1.0 (2025-08-19)"""
+from dataclasses import dataclass
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+
+@dataclass
+class Settings:
+    secret_key: str = os.getenv("SECRET_KEY", "secret")
+    remote_log_url: str | None = os.getenv("REMOTE_LOG_URL")
+    api_gateway_metrics_port: int = int(os.getenv("API_GATEWAY_METRICS_PORT", "9001"))
+    risk_engine_metrics_port: int = int(os.getenv("RISK_ENGINE_METRICS_PORT", "9002"))
+    db_host: str = os.getenv("DB_HOST", "localhost")
+    db_port: int = int(os.getenv("DB_PORT", "5432"))
+    db_name: str = os.getenv("DB_NAME", "cashmachiine")
+    db_user: str = os.getenv("DB_USER", "postgres")
+    db_pass: str = os.getenv("DB_PASS", "")
+    risk_engine_url: str = os.getenv("RISK_ENGINE_URL", "http://localhost:8000")
+
+
+settings = Settings()

--- a/data-ingestion/fetchers/base.py
+++ b/data-ingestion/fetchers/base.py
@@ -1,10 +1,11 @@
-"""Abstract OHLCV fetcher base v0.1.0"""
+"""Abstract OHLCV fetcher base v0.1.1 (2025-08-19)"""
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
-import os
 from typing import List
 import psycopg2
+
+from config import settings
 
 @dataclass
 class OHLCV:
@@ -29,11 +30,11 @@ class OHLCVFetcher(ABC):
         if not records:
             return
         conn = psycopg2.connect(
-            host=os.getenv("DB_HOST", "localhost"),
-            port=os.getenv("DB_PORT", "5432"),
-            dbname=os.getenv("DB_NAME", "cashmachiine"),
-            user=os.getenv("DB_USER", "postgres"),
-            password=os.getenv("DB_PASS", "")
+            host=settings.db_host,
+            port=settings.db_port,
+            dbname=settings.db_name,
+            user=settings.db_user,
+            password=settings.db_pass,
         )
         with conn, conn.cursor() as cur:
             for r in records:

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""orchestrator scheduler v0.3.1 (2025-08-19)"""
+"""orchestrator scheduler v0.3.2 (2025-08-19)"""
 import argparse
 import os
 import subprocess
@@ -9,6 +9,7 @@ from zoneinfo import ZoneInfo
 from apscheduler.schedulers.background import BackgroundScheduler
 
 from common.monitoring import setup_logging, setup_metrics, setup_tracer
+from config import settings
 
 
 tracer = setup_tracer("orchestrator")
@@ -31,7 +32,7 @@ def remove_service():
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Orchestrator controller v0.3.1")
+    parser = argparse.ArgumentParser(description="Orchestrator controller v0.3.2")
     parser.add_argument("--install", action="store_true", help="Install orchestrator service")
     parser.add_argument("--remove", action="store_true", help="Remove orchestrator service")
     parser.add_argument("--log-path", default=os.path.join("logs", "orchestrator.log"), help="Path to log file")
@@ -46,7 +47,7 @@ def main():
         return
 
     global logger, JOB_COUNTER
-    logger = setup_logging("orchestrator", log_path=args.log_path, remote_url=os.environ.get("REMOTE_LOG_URL"))
+    logger = setup_logging("orchestrator", log_path=args.log_path, remote_url=settings.remote_log_url)
     JOB_COUNTER = setup_metrics("orchestrator", port=args.metrics_port)
 
     scheduler = BackgroundScheduler(timezone=ZoneInfo("Europe/Paris"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# requirements.txt v0.2.6 (2025-08-19)
+# requirements.txt v0.2.7 (2025-08-19)
 
 # Runtime dependencies
 requests>=2.31.0
@@ -12,6 +12,7 @@ psycopg2-binary>=2.9.9
 numpy>=1.26.0
 prometheus-client>=0.20.0
 opentelemetry-sdk>=1.24.0
+python-dotenv>=1.0.1
 
 # Development dependencies
 pytest>=8.2.0

--- a/risk-engine/api.py
+++ b/risk-engine/api.py
@@ -1,15 +1,15 @@
-"""FastAPI endpoint for risk adjustments v0.3.1 (2025-08-19)"""
+"""FastAPI endpoint for risk adjustments v0.3.2 (2025-08-19)"""
 from __future__ import annotations
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
-import os
 from typing import List
 
 from fastapi import FastAPI, Request
 from pydantic import BaseModel
 
 from common.monitoring import setup_logging, setup_metrics, setup_tracer
+from config import settings
 
 try:  # local import when executed as module
     from .engine import volatility_target, var_es, kelly_fraction
@@ -38,8 +38,8 @@ class RiskResponse(BaseModel):
 
 
 app = FastAPI(title="risk-engine", version=__version__)
-logger = setup_logging("risk-engine", remote_url=os.environ.get("REMOTE_LOG_URL"))
-REQUEST_COUNT = setup_metrics("risk-engine", port=int(os.environ.get("METRICS_PORT", "9002")))
+logger = setup_logging("risk-engine", remote_url=settings.remote_log_url)
+REQUEST_COUNT = setup_metrics("risk-engine", port=settings.risk_engine_metrics_port)
 tracer = setup_tracer("risk-engine")
 
 

--- a/setup_env.cmd
+++ b/setup_env.cmd
@@ -1,4 +1,6 @@
 @echo off
-rem setup_env.cmd v0.1.0
+rem setup_env.cmd v0.2.0
 
 pip install -r "%~dp0requirements.txt"
+
+if not exist .env if exist .env.example copy .env.example .env

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-# setup_env.sh v0.1.0
+# setup_env.sh v0.2.0
 
 set -e
 
 pip install -r "$(dirname "$0")/requirements.txt"
+
+if [ ! -f .env ] && [ -f .env.example ]; then
+  cp .env.example .env
+fi

--- a/strategy-engine/risk_client.py
+++ b/strategy-engine/risk_client.py
@@ -1,7 +1,9 @@
-"""Risk-engine REST client v0.1.0 (2025-08-18)"""
+"""Risk-engine REST client v0.1.1 (2025-08-19)"""
 import requests
 
-__version__ = "0.1.0"
+from config import settings
+
+__version__ = "0.1.1"
 
 
 def adjust_risk(
@@ -15,7 +17,7 @@ def adjust_risk(
     edge,
     variance,
     kelly_cap,
-    url="http://localhost:8000"
+    url: str = settings.risk_engine_url
 ):
     """Call risk-engine `/adjust` endpoint and return JSON response."""
     payload = {

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,10 +1,11 @@
-# User Manual v0.6.1
+# User Manual v0.6.2
 
 Date: 2025-08-19
 
 This document will evolve into a comprehensive encyclopedia for the project.
 
 ## Installation
+- Copy `.env.example` to `.env` and adjust values as needed.
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
 - Each service provides `install.sh` and `remove.sh` scripts.
@@ -26,3 +27,4 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - If dependencies are missing, rerun `./setup_env.sh`.
 - Verify database connectivity with `php admin/db_check.php`.
 - Check service logs under the `logs/` directory for error details.
+- Ensure required variables are set in `.env`.

--- a/user_manual_2025-08-19.md
+++ b/user_manual_2025-08-19.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.0
+# User Manual v0.6.1
 
 Date: 2025-08-19
 
@@ -19,6 +19,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - db
 
 ## Installation
+- Copy `.env.example` to `.env` and adjust values as needed.
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
 - Each service includes install.sh and remove.sh scripts (v0.3.0).
@@ -40,8 +41,9 @@ This document will evolve into a comprehensive encyclopedia for the project.
 ## API Gateway
 - FastAPI service exposing `/goals` for users and `/actions` for admins.
 - Authenticate requests with JWT tokens containing a `role` claim.
-- All responses include header `X-API-Version: v0.2.1`.
+- All responses include header `X-API-Version: v0.2.2`.
 - Metrics default to port `9001`.
+ - Configuration values read from `config` package.
 
 ## Orchestrator
 - Uses APScheduler to trigger daily jobs at 08:00 Europe/Paris.
@@ -64,6 +66,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Provides volatility targeting, Value-at-Risk/Expected Shortfall checks, and Kelly fraction caps.
 - REST endpoint `/adjust` consumed by `strategy-engine` via `risk_client`.
 - Logs stored in `logs/risk-engine.log` and metrics default to port `9002`.
+ - Configuration values read from `config` package.
 
 ## Execution Engine
 - Broker-agnostic `OrderHandler` with pluggable adapters (`IBKR`, `Binance`).


### PR DESCRIPTION
## Summary
- add `config` package reading `.env` and environment variables
- integrate configuration into services and installers
- document `.env` usage and update dependencies

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a458507d50832c8bd736ad08bb7086