### PR TITLE
feat: add RabbitMQ messaging bus

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# .env.example v0.1.1 (2025-08-19)
+# .env.example v0.1.2 (2025-08-19)
 SECRET_KEY=change_me
 REMOTE_LOG_URL=
 API_GATEWAY_METRICS_PORT=9001
@@ -13,3 +13,4 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_DB=0
 RATE_LIMIT_PER_MINUTE=100
+RABBITMQ_URL=amqp://guest:guest@localhost:5672/

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.3
+# Changelog v0.6.4
 
 ## 2025-02-14
 - Introduced user manual revision with installation, usage, architecture and troubleshooting sections.
@@ -25,6 +25,9 @@
 - Added Redis-backed rate limiting middleware to api-gateway.
 - Updated configuration, environment samples and documentation for Redis settings.
 - Added `redis` and `fakeredis` dependencies.
+- Added RabbitMQ-based messaging package with producers and consumers.
+- Orchestrator now publishes events to the bus; data-ingestion consumes them.
+- Added broker installer scripts and `pika` dependency with configuration.
 
 ## 2025-08-18
 - Added initial development tasks outline.

--- a/changelog_2025-08-19.md
+++ b/changelog_2025-08-19.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.2
+# Changelog v0.6.3
 
 ## 2025-08-19
 - Added shared monitoring utilities providing JSON logging, Prometheus metrics and OpenTelemetry traces.
@@ -20,6 +20,9 @@
 - Added Redis-backed rate limiting middleware to api-gateway.
 - Updated configuration, environment samples and documentation for Redis settings.
 - Added `redis` and `fakeredis` dependencies.
+- Added RabbitMQ-based messaging package with producers and consumers.
+- Orchestrator now publishes events to the bus; data-ingestion consumes them.
+- Added broker installer scripts and `pika` dependency with configuration.
 
 ## 2025-08-18
 - Added initial development tasks outline.

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,4 +1,4 @@
-"""Configuration loader v0.1.1 (2025-08-19)"""
+"""Configuration loader v0.1.2 (2025-08-19)"""
 from dataclasses import dataclass
 from dotenv import load_dotenv
 import os
@@ -21,6 +21,7 @@ class Settings:
     redis_port: int = int(os.getenv("REDIS_PORT", "6379"))
     redis_db: int = int(os.getenv("REDIS_DB", "0"))
     rate_limit_per_minute: int = int(os.getenv("RATE_LIMIT_PER_MINUTE", "100"))
+    rabbitmq_url: str = os.getenv("RABBITMQ_URL", "amqp://guest:guest@localhost:5672/")
 
 
 settings = Settings()

--- a/data-ingestion/__init__.py
+++ b/data-ingestion/__init__.py
@@ -1,2 +1,2 @@
-"""data-ingestion service v0.3.0"""
-__version__ = "0.3.0"
+"""data-ingestion service v0.4.0"""
+__version__ = "0.4.0"

--- a/data-ingestion/install.sh
+++ b/data-ingestion/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# data-ingestion installer v0.3.0
+# data-ingestion installer v0.4.0
 echo "Installing data-ingestion service..."
-pip install yfinance ccxt psycopg2-binary
+pip install yfinance ccxt psycopg2-binary pika >/dev/null
 mkdir -p "$(dirname "$0")/logs"

--- a/data-ingestion/main.py
+++ b/data-ingestion/main.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""data-ingestion consumer v0.4.0 (2025-08-19)"""
+import argparse
+import os
+import subprocess
+
+from common.monitoring import setup_logging
+from config import settings
+from messaging import EventConsumer
+from data-ingestion.fetchers.equities_yahoo import YahooEquityFetcher
+
+
+def install_service():
+    script_path = os.path.join(os.path.dirname(__file__), "install.sh")
+    subprocess.run([script_path], check=True)
+
+
+def remove_service():
+    script_path = os.path.join(os.path.dirname(__file__), "remove.sh")
+    subprocess.run([script_path], check=True)
+
+
+def handle_event(message: dict) -> None:
+    event = message.get("event")
+    if event == "fetch_equities":
+        symbol = message.get("payload", {}).get("symbol", "AAPL")
+        fetcher = YahooEquityFetcher()
+        fetcher.save(fetcher.fetch(symbol))
+        logger.info("Fetched equities for %s", symbol)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="data-ingestion consumer v0.4.0")
+    parser.add_argument("--install", action="store_true", help="Install data-ingestion service")
+    parser.add_argument("--remove", action="store_true", help="Remove data-ingestion service")
+    parser.add_argument("--log-path", default=os.path.join("logs", "data-ingestion.log"), help="Path to log file")
+    args = parser.parse_args()
+
+    if args.install:
+        install_service()
+        return
+    if args.remove:
+        remove_service()
+        return
+
+    global logger
+    logger = setup_logging("data-ingestion", log_path=args.log_path, remote_url=settings.remote_log_url)
+
+    consumer = EventConsumer(settings.rabbitmq_url, queue="data-ingestion")
+    try:
+        consumer.start(handle_event)
+    finally:
+        consumer.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/data-ingestion/remove.sh
+++ b/data-ingestion/remove.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# data-ingestion removal v0.3.0
+# data-ingestion removal v0.4.0
 echo "Removing data-ingestion service..."
-pip uninstall yfinance ccxt psycopg2-binary -y
+pip uninstall yfinance ccxt psycopg2-binary pika -y >/dev/null

--- a/install_rabbitmq.sh
+++ b/install_rabbitmq.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# rabbitmq installer v0.1.0 (2025-08-19)
+set -e
+
+docker run -d --name rabbitmq -p 5672:5672 rabbitmq:3-alpine

--- a/messaging/__init__.py
+++ b/messaging/__init__.py
@@ -1,0 +1,5 @@
+"""messaging utilities v0.1.0 (2025-08-19)"""
+__all__ = ["EventProducer", "EventConsumer"]
+
+from .producer import EventProducer
+from .consumer import EventConsumer

--- a/messaging/consumer.py
+++ b/messaging/consumer.py
@@ -1,0 +1,28 @@
+"""RabbitMQ event consumer v0.1.0 (2025-08-19)"""
+import json
+import pika
+from typing import Callable, Any
+
+
+class EventConsumer:
+    """Consume events from a RabbitMQ exchange."""
+
+    def __init__(self, url: str, queue: str, exchange: str = "events"):
+        self._conn = pika.BlockingConnection(pika.URLParameters(url))
+        self._channel = self._conn.channel()
+        self._channel.exchange_declare(exchange=exchange, exchange_type="fanout", durable=True)
+        self._channel.queue_declare(queue=queue, durable=True)
+        self._channel.queue_bind(queue=queue, exchange=exchange)
+        self._queue = queue
+
+    def start(self, handler: Callable[[dict], Any]) -> None:
+        def _callback(ch, method, properties, body):
+            message = json.loads(body)
+            handler(message)
+            ch.basic_ack(delivery_tag=method.delivery_tag)
+
+        self._channel.basic_consume(queue=self._queue, on_message_callback=_callback)
+        self._channel.start_consuming()
+
+    def close(self) -> None:
+        self._conn.close()

--- a/messaging/producer.py
+++ b/messaging/producer.py
@@ -1,0 +1,21 @@
+"""RabbitMQ event producer v0.1.0 (2025-08-19)"""
+import json
+import pika
+
+
+class EventProducer:
+    """Publish events to a RabbitMQ exchange."""
+
+    def __init__(self, url: str, exchange: str = "events"):
+        self._url = url
+        self._exchange = exchange
+        self._conn = pika.BlockingConnection(pika.URLParameters(url))
+        self._channel = self._conn.channel()
+        self._channel.exchange_declare(exchange=exchange, exchange_type="fanout", durable=True)
+
+    def publish(self, event: str, payload: dict) -> None:
+        body = json.dumps({"event": event, "payload": payload})
+        self._channel.basic_publish(exchange=self._exchange, routing_key="", body=body)
+
+    def close(self) -> None:
+        self._conn.close()

--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -1,2 +1,2 @@
-"""orchestrator service v0.3.0"""
-__version__ = "0.3.0"
+"""orchestrator service v0.4.0"""
+__version__ = "0.4.0"

--- a/orchestrator/install.sh
+++ b/orchestrator/install.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-# orchestrator installer v0.3.0
+# orchestrator installer v0.4.0
 echo "Installing orchestrator service..."
+pip install pika >/dev/null

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""orchestrator scheduler v0.3.2 (2025-08-19)"""
+"""orchestrator scheduler v0.4.0 (2025-08-19)"""
 import argparse
 import os
 import subprocess
@@ -10,15 +10,17 @@ from apscheduler.schedulers.background import BackgroundScheduler
 
 from common.monitoring import setup_logging, setup_metrics, setup_tracer
 from config import settings
+from messaging import EventProducer
 
 
 tracer = setup_tracer("orchestrator")
 
 
-def sample_job():
+def sample_job(producer: EventProducer):
     with tracer.start_as_current_span("sample_job"):
         JOB_COUNTER.inc()
         logger.info("Orchestrator job executed")
+        producer.publish("fetch_equities", {"symbol": "AAPL"})
 
 
 def install_service():
@@ -32,7 +34,7 @@ def remove_service():
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Orchestrator controller v0.3.2")
+    parser = argparse.ArgumentParser(description="Orchestrator controller v0.4.0")
     parser.add_argument("--install", action="store_true", help="Install orchestrator service")
     parser.add_argument("--remove", action="store_true", help="Remove orchestrator service")
     parser.add_argument("--log-path", default=os.path.join("logs", "orchestrator.log"), help="Path to log file")
@@ -50,8 +52,9 @@ def main():
     logger = setup_logging("orchestrator", log_path=args.log_path, remote_url=settings.remote_log_url)
     JOB_COUNTER = setup_metrics("orchestrator", port=args.metrics_port)
 
+    producer = EventProducer(settings.rabbitmq_url)
     scheduler = BackgroundScheduler(timezone=ZoneInfo("Europe/Paris"))
-    scheduler.add_job(sample_job, "cron", hour=8, minute=0)
+    scheduler.add_job(sample_job, "cron", hour=8, minute=0, args=[producer])
     scheduler.start()
     logger.info("Scheduler started, waiting for jobs")
     try:
@@ -59,6 +62,7 @@ def main():
             time.sleep(1)
     except (KeyboardInterrupt, SystemExit):
         scheduler.shutdown()
+        producer.close()
 
 
 if __name__ == "__main__":

--- a/orchestrator/remove.sh
+++ b/orchestrator/remove.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-# orchestrator removal v0.3.0
+# orchestrator removal v0.4.0
 echo "Removing orchestrator service..."
+pip uninstall pika -y >/dev/null

--- a/remove_rabbitmq.sh
+++ b/remove_rabbitmq.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# rabbitmq removal v0.1.0 (2025-08-19)
+set -e
+
+docker rm -f rabbitmq 2>/dev/null || true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# requirements.txt v0.2.8 (2025-08-19)
+# requirements.txt v0.2.9 (2025-08-19)
 
 # Runtime dependencies
 requests>=2.31.0
@@ -14,6 +14,7 @@ prometheus-client>=0.20.0
 opentelemetry-sdk>=1.24.0
 python-dotenv>=1.0.1
 redis>=5.0.0
+pika>=1.3.2
 
 # Development dependencies
 pytest>=8.2.0

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.3
+# User Manual v0.6.4
 
 Date: 2025-08-19
 
@@ -9,11 +9,13 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
 - Each service provides `install.sh` and `remove.sh` scripts.
+- Install RabbitMQ with `./install_rabbitmq.sh` and remove it with `./remove_rabbitmq.sh`.
 
 ## Usage
 - Authenticate and interact with the API Gateway at `/goals` and `/actions`.
 - Rate limiting is enforced per IP via Redis; defaults to 100 requests per minute.
 - Start the scheduler with `python orchestrator/main.py`.
+- Data ingestion consumes events from the scheduler via RabbitMQ.
 - Pass `--install` or `--remove` to service scripts for setup and teardown.
 
 ## Architecture

--- a/user_manual_2025-08-19.md
+++ b/user_manual_2025-08-19.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.2
+# User Manual v0.6.3
 
 Date: 2025-08-19
 
@@ -12,6 +12,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - api-gateway
 - orchestrator
 - data-ingestion
+- messaging
 - strategy-engine
 - risk-engine
 - execution-engine
@@ -26,6 +27,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
 - Each service includes install.sh and remove.sh scripts (v0.3.0).
+- Install RabbitMQ with `./install_rabbitmq.sh` and remove it with `./remove_rabbitmq.sh`.
 
 ## Database Setup
 - Run `./install_db.sh` to create tables.
@@ -50,13 +52,14 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Configuration values read from `config` package.
 
 ## Orchestrator
-- Uses APScheduler to trigger daily jobs at 08:00 Europe/Paris.
+- Uses APScheduler to trigger daily jobs at 08:00 Europe/Paris and publishes events to RabbitMQ.
 - Start with `python orchestrator/main.py`.
 - Flags: `--install` to install, `--remove` to uninstall, `--log-path` to customize log file, `--metrics-port` for metrics.
 - Default log file `logs/orchestrator.log`.
 
 ## Data Ingestion
 - Modular fetchers for Yahoo equities and Binance crypto.
+- Consumes RabbitMQ events and fetches data on demand.
 - Example usage:
   - `from data_ingestion.fetchers.equities_yahoo import YahooEquityFetcher`
   - `YahooEquityFetcher().save(YahooEquityFetcher().fetch("AAPL"))`


### PR DESCRIPTION
## Summary
- add RabbitMQ-based messaging package with producer and consumer utilities
- publish fetch events from orchestrator and consume them in data-ingestion
- provide broker installer scripts and dependency updates

## Testing
- `pip install pika`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a45d419014832c882c1b0e3d559bfa