### PR TITLE
Add security scans to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# ci.yml v0.1.0
+# ci.yml v0.2.0
 name: CI
 
 on:
@@ -19,9 +19,33 @@ jobs:
       - name: Lint
         run: python -m compileall .
 
-  test:
+  security:
     runs-on: ubuntu-latest
     needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Bandit security scan
+        run: bandit -r .
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Install UI dependencies
+        working-directory: ui
+        run: npm install
+      - name: npm audit
+        working-directory: ui
+        run: npm audit --audit-level=moderate
+
+  test:
+    runs-on: ubuntu-latest
+    needs: security
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -48,3 +72,4 @@ jobs:
           else
             echo "No Dockerfile for ${{ matrix.service }}, skipping."
           fi
+

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.5
+# Changelog v0.6.6
 
 ## 2025-02-14
 - Introduced user manual revision with installation, usage, architecture and troubleshooting sections.
@@ -32,6 +32,9 @@
 - Introduced root docker-compose.yml wiring services, database, cache and message bus.
 - Updated setup/remove scripts to invoke `docker-compose up` and `docker-compose down`.
 - Extended log creation scripts to include container log directories.
+- Added Bandit and `npm audit` security scans to CI with automatic dependency alerts.
+- Added Bandit dependency and UI `audit` script.
+- Documented security policies in user manuals.
 
 ## 2025-08-18
 - Added initial development tasks outline.
@@ -74,3 +77,4 @@
 - Expanded user manual with execution-engine order handling and bumped to v0.5.5.
 - Added backtester CLI for HTML reports with install/remove commands, tests, and report directories.
 - Updated user manual and log creation scripts; ignored report outputs.
+

--- a/changelog_2025-08-19.md
+++ b/changelog_2025-08-19.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.4
+# Changelog v0.6.5
 
 ## 2025-08-19
 - Added shared monitoring utilities providing JSON logging, Prometheus metrics and OpenTelemetry traces.
@@ -27,6 +27,9 @@
 - Introduced root docker-compose.yml wiring services, database, cache and message bus.
 - Updated setup/remove scripts to invoke `docker-compose up` and `docker-compose down`.
 - Extended log creation scripts to include container log directories.
+- Added Bandit and `npm audit` security scans to CI with automatic dependency alerts.
+- Added Bandit dependency and UI `audit` script.
+- Documented security policies in user manuals.
 
 ## 2025-08-18
 - Added initial development tasks outline.
@@ -69,3 +72,4 @@
 - Expanded user manual with execution-engine order handling and bumped to v0.5.5.
 - Added backtester CLI for HTML reports with install/remove commands, tests, and report directories.
 - Updated user manual and log creation scripts; ignored report outputs.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# requirements.txt v0.2.9 (2025-08-19)
+# requirements.txt v0.3.0 (2025-08-19)
 
 # Runtime dependencies
 requests>=2.31.0
@@ -20,3 +20,5 @@ pika>=1.3.2
 pytest>=8.2.0
 httpx>=0.27.0
 fakeredis>=2.21.0
+bandit>=1.7.5
+

--- a/ui/install.sh
+++ b/ui/install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# ui installer v0.2.0 (2025-08-19)
+# ui installer v0.3.0 (2025-08-19)
 set -e
 cd "$(dirname "$0")"
 npm install
+

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,11 +1,12 @@
 {
   "name": "cashmachiine-ui",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "echo \"No tests\""
+    "test": "echo \"No tests\"",
+    "audit": "npm audit"
   },
   "dependencies": {
     "autoprefixer": "10.4.16",

--- a/ui/remove.sh
+++ b/ui/remove.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# ui removal v0.2.0 (2025-08-19)
+# ui removal v0.3.0 (2025-08-19)
 set -e
 cd "$(dirname "$0")"
 rm -rf node_modules .next
+

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.5
+# User Manual v0.6.6
 
 Date: 2025-08-19
 
@@ -27,8 +27,14 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - The `ci.yml` workflow runs lint, tests and builds service images on each push or pull request.
 - Badges in the README display the latest status for `lint`, `test` and `build` jobs.
 
+## Security Policies
+- The CI pipeline scans Python code with Bandit and frontend dependencies with `npm audit`.
+- Dependency vulnerabilities cause the pipeline to fail, providing automatic alerts.
+- Developers can run `bandit -r .` and `npm run audit` locally before pushing changes.
+
 ## Troubleshooting
 - If dependencies are missing, rerun `./setup_env.sh`.
 - Verify database connectivity with `php admin/db_check.php`.
 - Check service logs under the `logs/` directory for error details.
 - Ensure required variables are set in `.env`.
+

--- a/user_manual_2025-08-19.md
+++ b/user_manual_2025-08-19.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.4
+# User Manual v0.6.5
 
 Date: 2025-08-19
 
@@ -43,6 +43,11 @@ This document will evolve into a comprehensive encyclopedia for the project.
 ## Continuous Integration
 - GitHub Actions `ci.yml` workflow runs lint, tests and builds service images.
 - Status badges in the README show the latest pipeline results.
+
+## Security Policies
+- The CI pipeline scans Python code with Bandit and frontend dependencies with `npm audit`.
+- Dependency vulnerabilities cause the pipeline to fail, providing automatic alerts.
+- Developers can run `bandit -r .` and `npm run audit` locally before pushing changes.
 
 ## API Gateway
 - FastAPI service exposing `/goals` for users and `/actions` for admins.
@@ -94,7 +99,8 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Next.js frontend with Tailwind CSS.
 - `/goals` page submits new goals to the API Gateway `/goals` endpoint.
 - `/daily-actions` page displays recommendations fetched from `/actions`.
-- Install with `ui/install.sh` and remove with `ui/remove.sh` (v0.2.0).
+- Install with `ui/install.sh` and remove with `ui/remove.sh` (v0.3.0).
 - Screenshots:
   - Goal creation page (screenshot omitted)
   - Daily actions page (screenshot omitted)
+


### PR DESCRIPTION
## Summary
- run Bandit and npm audit in CI
- add Bandit dependency and audit script
- document security policies

## Testing
- `pytest`
- `bandit -r .`
- `npm run audit` *(fails: requires audit fixes)*

------
https://chatgpt.com/codex/tasks/task_e_68a461a8085c832ca9592761610389b2