### PR TITLE
feat: add benchmarking and performance metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# .gitignore v0.2.9 (2025-08-19)
+# .gitignore v0.2.10 (2025-08-19)
 # Python artifacts
 __pycache__/
 *.py[cod]
@@ -33,3 +33,4 @@ db/data/
 .DS_Store
 logs/
 backtester/reports/
+perf/

--- a/api-gateway/tests/test_benchmark_api_gateway.py
+++ b/api-gateway/tests/test_benchmark_api_gateway.py
@@ -1,0 +1,33 @@
+"""Benchmark tests for api-gateway v0.1.0 (2025-08-19)"""
+from fastapi.testclient import TestClient
+from jose import jwt
+import importlib.util
+from pathlib import Path
+import sys
+
+from pytest_benchmark.fixture import BenchmarkFixture
+
+# Ensure project root on sys.path for common package
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "main.py"
+SPEC = importlib.util.spec_from_file_location("api_gateway_main", MODULE_PATH)
+main = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(main)
+
+client = TestClient(main.app)
+SECRET_KEY = main.SECRET_KEY
+ALGORITHM = main.ALGORITHM
+
+
+def create_token(role: str):
+    return jwt.encode({"role": role}, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def bench_request():
+    token = create_token("user")
+    client.get("/goals", headers={"Authorization": f"Bearer {token}"})
+
+
+def test_get_goals_benchmark(benchmark: BenchmarkFixture):
+    benchmark(bench_request)

--- a/api-gateway/tests/test_main.py
+++ b/api-gateway/tests/test_main.py
@@ -1,4 +1,4 @@
-"""Unit tests for api-gateway main application v0.2.3 (2025-08-19)"""
+"""Unit tests for api-gateway main application v0.2.4 (2025-08-19)"""
 from fastapi.testclient import TestClient
 from jose import jwt
 import importlib.util
@@ -32,7 +32,7 @@ def test_goals_returns_version_header_and_data():
     token = create_token("user")
     response = client.get("/goals", headers={"Authorization": f"Bearer {token}"})
     assert response.status_code == 200
-    assert response.headers["X-API-Version"] == "v0.2.3"
+    assert response.headers["X-API-Version"] == "v0.2.4"
     assert response.json() == {"goals": []}
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.6
+# Changelog v0.6.7
 
 ## 2025-02-14
 - Introduced user manual revision with installation, usage, architecture and troubleshooting sections.
@@ -35,6 +35,12 @@
 - Added Bandit and `npm audit` security scans to CI with automatic dependency alerts.
 - Added Bandit dependency and UI `audit` script.
 - Documented security policies in user manuals.
+
+- Introduced pytest-benchmark scripts for api-gateway and strategy-engine.
+- Stored benchmark results under `perf/` and updated log creation scripts.
+- Added Prometheus latency metrics via `setup_performance_metrics`.
+- Documented benchmarking and metrics in user manual.
+- Added `pytest-benchmark` dependency and ignored `perf/` artifacts.
 
 ## 2025-08-18
 - Added initial development tasks outline.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# requirements.txt v0.3.0 (2025-08-19)
+# requirements.txt v0.3.1 (2025-08-19)
 
 # Runtime dependencies
 requests>=2.31.0
@@ -21,4 +21,5 @@ pytest>=8.2.0
 httpx>=0.27.0
 fakeredis>=2.21.0
 bandit>=1.7.5
+pytest-benchmark>=4.0.0
 

--- a/strategy-engine/strategies/core.py
+++ b/strategy-engine/strategies/core.py
@@ -1,14 +1,18 @@
-"""Core strategy example v0.1.0 (2025-08-18)"""
+"""Core strategy example v0.1.1 (2025-08-19)"""
 from ..interface import Strategy
+from common.monitoring import setup_performance_metrics
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
+
+SIGNAL_LATENCY = setup_performance_metrics("strategy-engine-core")
 
 
 class CoreStrategy(Strategy):
     """Long-term core allocation example."""
 
     def signals(self, market_data):
-        return {"SPY": 1.0}
+        with SIGNAL_LATENCY.time():
+            return {"SPY": 1.0}
 
     def target_weights(self, signals):
         return {"SPY": 1.0}

--- a/strategy-engine/strategies/satellite.py
+++ b/strategy-engine/strategies/satellite.py
@@ -1,14 +1,18 @@
-"""Satellite strategy example v0.1.0 (2025-08-18)"""
+"""Satellite strategy example v0.1.1 (2025-08-19)"""
 from ..interface import Strategy
+from common.monitoring import setup_performance_metrics
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
+
+SIGNAL_LATENCY = setup_performance_metrics("strategy-engine-satellite")
 
 
 class SatelliteStrategy(Strategy):
     """Tactical satellite allocation example."""
 
     def signals(self, market_data):
-        return {"BTC": 0.5}
+        with SIGNAL_LATENCY.time():
+            return {"BTC": 0.5}
 
     def target_weights(self, signals):
         return {"BTC": 0.1}

--- a/strategy-engine/tests/test_benchmark_strategy_engine.py
+++ b/strategy-engine/tests/test_benchmark_strategy_engine.py
@@ -1,0 +1,26 @@
+"""Benchmark tests for strategy-engine v0.1.0 (2025-08-19)"""
+import importlib.util
+import sys
+from pathlib import Path
+
+from pytest_benchmark.fixture import BenchmarkFixture
+
+ENGINE_DIR = Path(__file__).resolve().parents[1]
+sys.path.append(str(ENGINE_DIR.parent))
+
+
+def load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+interface = load("strategy_engine.interface", ENGINE_DIR / "interface.py")
+core = load("strategy_engine.strategies.core", ENGINE_DIR / "strategies/core.py")
+
+
+def test_core_strategy_signals_benchmark(benchmark: BenchmarkFixture):
+    strategy = core.CoreStrategy()
+    benchmark(strategy.signals, {})

--- a/tools/log_create.sh
+++ b/tools/log_create.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# log directory creator v0.6.2 (2025-08-19)
+# log directory creator v0.6.3 (2025-08-19)
 set -e
 mkdir -p logs
 mkdir -p logs/containers
 mkdir -p backtester/reports
 mkdir -p ui/.next
+mkdir -p perf

--- a/tools/log_create_win.cmd
+++ b/tools/log_create_win.cmd
@@ -1,6 +1,7 @@
 @echo off
-REM log directory creator v0.6.2 (2025-08-19)
+REM log directory creator v0.6.3 (2025-08-19)
 mkdir logs 2>nul
 mkdir logs\containers 2>nul
 mkdir backtester\reports 2>nul
 mkdir ui\.next 2>nul
+mkdir perf 2>nul

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.6
+# User Manual v0.6.7
 
 Date: 2025-08-19
 
@@ -18,6 +18,12 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Start the scheduler with `python orchestrator/main.py`.
 - Data ingestion consumes events from the scheduler via RabbitMQ.
 - Pass `--install` or `--remove` to service scripts for setup and teardown.
+
+## Performance
+- Run benchmarks with `pytest --benchmark-json=perf/<service>/results.json`.
+- Benchmark tests cover `api-gateway` and `strategy-engine`.
+- Prometheus exposes latency metrics on each service's metrics port.
+- Benchmark results are stored under `perf/`.
 
 ## Architecture
 - Services communicate via structured logs, metrics, and traces.


### PR DESCRIPTION
## Summary
- add pytest-benchmark suites for API gateway and strategy engine
- expose Prometheus latency metrics alongside existing counters
- document benchmark workflow and create perf directory in log scripts

## Testing
- `pytest`
- `pytest api-gateway/tests/test_benchmark_api_gateway.py --benchmark-json=perf/api-gateway/benchmark.json`
- `pytest api-gateway/tests/test_benchmark_api_gateway.py strategy-engine/tests/test_benchmark_strategy_engine.py --benchmark-json=perf/combined.json`


------
https://chatgpt.com/codex/tasks/task_e_68a4639e5700832c99c66cf43102623a