### PR TITLE
Add Alpha Vantage bond/commodity fetchers and enable TimescaleDB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# .env.example v0.1.2 (2025-08-19)
+# .env.example v0.1.3 (2025-08-19)
 SECRET_KEY=change_me
 REMOTE_LOG_URL=
 API_GATEWAY_METRICS_PORT=9001
@@ -14,3 +14,4 @@ REDIS_PORT=6379
 REDIS_DB=0
 RATE_LIMIT_PER_MINUTE=100
 RABBITMQ_URL=amqp://guest:guest@localhost:5672/
+ALPHA_VANTAGE_KEY=demo

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Goal-Based Investment Copilot — Spécification fonctionnelle v0.1.3
+# Goal-Based Investment Copilot — Spécification fonctionnelle v0.1.4
 
 [![Lint](https://github.com/OpenAI/CashMachiine/actions/workflows/ci.yml/badge.svg?branch=main&job=lint)](https://github.com/OpenAI/CashMachiine/actions/workflows/ci.yml?query=branch%3Amain)
 [![Tests](https://github.com/OpenAI/CashMachiine/actions/workflows/ci.yml/badge.svg?branch=main&job=test)](https://github.com/OpenAI/CashMachiine/actions/workflows/ci.yml?query=branch%3Amain)
@@ -64,6 +64,7 @@ Construire un logiciel qui, à partir d’un **capital initial**, d’un **objec
 ## 5) Données & connecteurs (modulaires)
 
 * **Prix & fondamentaux** : actions/ETF (Euronext/US), obligations, matières premières, FX, crypto.
+* Fetchers Alpha Vantage pour obligations et matières premières via le bus de messages.
 * **Flux crypto** : CEX (Binance/Kraken/Bybit), DEX (via indexeurs), funding, open interest (si autorisé).
 * **Macro/news/sentiment** (optionnels, pondérés faiblement par défaut).
 * **Courtiers / exécution** : IBKR, Degiro, Binance, Kraken… (clé API, sandbox d’abord).

--- a/admin/db_check.php
+++ b/admin/db_check.php
@@ -1,6 +1,6 @@
 <?php
-// db_check.php v0.1.2 (2025-08-19)
-$expectedVersion = 'v0.1.0';
+// db_check.php v0.1.3 (2025-08-19)
+$expectedVersion = 'v0.1.1';
 $dsn = sprintf('pgsql:host=%s;port=%s;dbname=%s',
     getenv('DB_HOST') ?: 'localhost',
     getenv('DB_PORT') ?: '5432',
@@ -24,6 +24,16 @@ foreach ($requiredTables as $tbl) {
         echo "Missing table: $tbl\n";
         exit(1);
     }
+}
+$stmt = $pdo->query("SELECT extname FROM pg_extension WHERE extname='timescaledb'");
+if (!$stmt->fetchColumn()) {
+    echo "Missing extension: timescaledb\n";
+    exit(1);
+}
+$stmt = $pdo->query("SELECT 1 FROM timescaledb_information.hypertables WHERE hypertable_name='prices'");
+if (!$stmt->fetchColumn()) {
+    echo "prices table is not a hypertable\n";
+    exit(1);
 }
 $stmt = $pdo->query("SELECT column_name FROM information_schema.columns WHERE table_name='prices'");
 $cols = $stmt->fetchAll(PDO::FETCH_COLUMN);

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.18
+# Changelog v0.6.19
 
 ## 2025-02-14
 - Introduced user manual revision with installation, usage, architecture and troubleshooting sections.
@@ -62,6 +62,9 @@
   `messaging.log` path with version bumps across orchestrator and dependent services.
 
 - Added per-service `requirements.txt` files with updated Dockerfiles and install scripts to eliminate build warnings.
+ - Added Alpha Vantage bond and commodity fetchers with message bus integration.
+ - Enabled TimescaleDB extension and converted `prices` to a hypertable with migration and schema checks.
+ - Updated install script and documentation for TimescaleDB.
 
 ## 2025-08-18
 - Added initial development tasks outline.

--- a/changelog_2025-08-19.md
+++ b/changelog_2025-08-19.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.16
+# Changelog v0.6.17
 
 ## 2025-08-19
 - Added shared monitoring utilities providing JSON logging, Prometheus metrics and OpenTelemetry traces.
@@ -88,4 +88,8 @@
 - Expanded user manual with execution-engine order handling and bumped to v0.5.5.
 - Added backtester CLI for HTML reports with install/remove commands, tests, and report directories.
 - Updated user manual and log creation scripts; ignored report outputs.
+
+- Added Alpha Vantage bond and commodity fetchers with message bus integration.
+- Enabled TimescaleDB extension and converted `prices` to a hypertable with migration and schema checks.
+- Updated install script and documentation for TimescaleDB.
 

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,4 +1,4 @@
-"""Configuration loader v0.1.2 (2025-08-19)"""
+"""Configuration loader v0.1.3 (2025-08-19)"""
 from dataclasses import dataclass
 from dotenv import load_dotenv
 import os
@@ -22,6 +22,7 @@ class Settings:
     redis_db: int = int(os.getenv("REDIS_DB", "0"))
     rate_limit_per_minute: int = int(os.getenv("RATE_LIMIT_PER_MINUTE", "100"))
     rabbitmq_url: str = os.getenv("RABBITMQ_URL", "amqp://guest:guest@localhost:5672/")
+    alpha_vantage_key: str = os.getenv("ALPHA_VANTAGE_KEY", "demo")
 
 
 settings = Settings()

--- a/data-ingestion/fetchers/bonds_alpha_vantage.py
+++ b/data-ingestion/fetchers/bonds_alpha_vantage.py
@@ -1,0 +1,30 @@
+"""Alpha Vantage bonds fetcher v0.1.0 (2025-08-19)"""
+from datetime import datetime, timezone
+import requests
+
+from .base import OHLCV, OHLCVFetcher
+from config import settings
+
+
+class AlphaVantageBondFetcher(OHLCVFetcher):
+    """Fetch daily treasury yields from Alpha Vantage."""
+
+    venue = "ALPHAVANTAGE"
+
+    def fetch(self, symbol: str):
+        url = "https://www.alphavantage.co/query"
+        params = {
+            "function": "TREASURY_YIELD",
+            "interval": "daily",
+            "apikey": settings.alpha_vantage_key,
+        }
+        resp = requests.get(url, params=params, timeout=10)
+        data = resp.json().get("data", [])
+        records: list[OHLCV] = []
+        for row in data:
+            ts = datetime.strptime(row["date"], "%Y-%m-%d").replace(tzinfo=timezone.utc)
+            yld = float(row["value"])
+            records.append(
+                OHLCV(symbol=symbol, venue=self.venue, ts=ts, o=yld, h=yld, l=yld, c=yld, v=0.0)
+            )
+        return records

--- a/data-ingestion/fetchers/commodities_alpha_vantage.py
+++ b/data-ingestion/fetchers/commodities_alpha_vantage.py
@@ -1,0 +1,39 @@
+"""Alpha Vantage commodities fetcher v0.1.0 (2025-08-19)"""
+from datetime import datetime, timezone
+import requests
+
+from .base import OHLCV, OHLCVFetcher
+from config import settings
+
+
+class AlphaVantageCommodityFetcher(OHLCVFetcher):
+    """Fetch daily commodity prices from Alpha Vantage."""
+
+    venue = "ALPHAVANTAGE"
+
+    def fetch(self, symbol: str):
+        url = "https://www.alphavantage.co/query"
+        params = {
+            "function": "TIME_SERIES_DAILY",
+            "symbol": symbol,
+            "apikey": settings.alpha_vantage_key,
+        }
+        resp = requests.get(url, params=params, timeout=10)
+        data = resp.json().get("Time Series (Daily)", {})
+        records: list[OHLCV] = []
+        for date_str, row in data.items():
+            ts = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+            records.append(
+                OHLCV(
+                    symbol=symbol,
+                    venue=self.venue,
+                    ts=ts,
+                    o=float(row["1. open"]),
+                    h=float(row["2. high"]),
+                    l=float(row["3. low"]),
+                    c=float(row["4. close"]),
+                    v=float(row["5. volume"]),
+                )
+            )
+            break
+        return records

--- a/db/migrations/014_enable_timescaledb.sql
+++ b/db/migrations/014_enable_timescaledb.sql
@@ -1,0 +1,3 @@
+-- enable timescaledb and convert prices to hypertable v0.1.0 (2025-08-19)
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+SELECT create_hypertable('prices', 'ts', if_not_exists => TRUE);

--- a/install_db.sh
+++ b/install_db.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# install_db.sh v0.1.0
+# install_db.sh v0.1.1 (2025-08-19)
 set -e
+psql "$@" -c "CREATE EXTENSION IF NOT EXISTS timescaledb;"
 for file in db/migrations/*.sql; do
   echo "Applying $file"
   psql "$@" -f "$file"

--- a/orchestrator/main.py
+++ b/orchestrator/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""orchestrator scheduler v0.5.2 (2025-08-19)"""
+"""orchestrator scheduler v0.5.3 (2025-08-19)"""
 import argparse
 import os
 import subprocess  # nosec B404
@@ -21,7 +21,9 @@ def run_pipeline(producer: EventProducer):
     with tracer.start_as_current_span("run_pipeline"):
         JOB_COUNTER.inc()
         logger.info("Starting pipeline dispatch")
-        producer.publish("data_fetch", {"symbol": "AAPL"})
+        producer.publish("data_fetch", {"symbol": "AAPL", "asset_class": "equity"})
+        producer.publish("data_fetch", {"symbol": "US10Y", "asset_class": "bond"})
+        producer.publish("data_fetch", {"symbol": "GC=F", "asset_class": "commodity"})
         producer.publish("strategy_compute", {})
         producer.publish("risk_adjust", {"weights": [1.0], "current_vol": 0.05, "target_vol": 0.1})
         producer.publish(
@@ -42,7 +44,7 @@ def remove_service():
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Orchestrator controller v0.5.2")
+    parser = argparse.ArgumentParser(description="Orchestrator controller v0.5.3")
     parser.add_argument("--install", action="store_true", help="Install orchestrator service")
     parser.add_argument("--remove", action="store_true", help="Remove orchestrator service")
     parser.add_argument("--log-path", default=os.path.join("logs", "orchestrator.log"), help="Path to log file")

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,6 +1,6 @@
-# User Manual v0.6.19
+# User Manual v0.6.20
 
-Date: 2025-08-20
+Date: 2025-08-19
 
 This document will evolve into a comprehensive encyclopedia for the project.
 
@@ -8,7 +8,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Refer to [development_tasks.md](development_tasks.md) for the latest task status.
 
 ## Installation
-- Copy `.env.example` to `.env` and adjust values as needed, including `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB` and `RATE_LIMIT_PER_MINUTE`.
+- Copy `.env.example` to `.env` and adjust values as needed, including `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, `RATE_LIMIT_PER_MINUTE` and `ALPHA_VANTAGE_KEY`.
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
 - Each service provides `install.sh` and `remove.sh` scripts.
@@ -17,6 +17,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - UI translation assets install with `ui/install_locales.sh` and remove with `ui/remove_locales.sh`.
 - Install RabbitMQ with `./install_rabbitmq.sh` and remove it with `./remove_rabbitmq.sh`.
 - Start all services with `docker-compose up -d` and stop them with `docker-compose down`.
+- Run `./install_db.sh` to apply migrations; the script enables TimescaleDB and converts `prices` to a hypertable.
 
 ## Usage
 - Authenticate and interact with the API Gateway at `/goals`, `/goals/{id}/status`, `/actions/today`, `/actions/{id}/check` and `/orders/preview`.
@@ -24,7 +25,8 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Rate limiting is enforced per IP via Redis; defaults to 100 requests per minute.
 - Start the scheduler with `python orchestrator/main.py`.
  - The orchestrator sequentially dispatches `data_fetch`, `strategy_compute`, `risk_adjust` and `order_dispatch` events.
- - Data ingestion, strategy-engine, risk-engine and execution-engine consume these events from RabbitMQ.
+ - `data_fetch` covers equities, bonds and commodities via Alpha Vantage fetchers.
+- Data ingestion, strategy-engine, risk-engine and execution-engine consume these events from RabbitMQ.
 - Pass `--install` or `--remove` to service scripts for setup and teardown.
 - The UI supports French and English; append `/en` to URLs to switch to English.
 - Visualize aggregated metrics via the `/analytics` endpoint or the UI analytics page.


### PR DESCRIPTION
## Summary
- add Alpha Vantage bond and commodity fetchers wired through the message bus
- enable TimescaleDB and convert prices table to hypertable with migration and checks
- document new fetchers and database setup across README, manual and changelog

## Testing
- `pytest`
- `bandit -r .`


------
https://chatgpt.com/codex/tasks/task_e_68a4b841cdb4832cb5abf380560711c1