### PR TITLE
feat: add broker adapters with DB persistence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# .env.example v0.1.3 (2025-08-19)
+# .env.example v0.1.4 (2025-08-19)
 SECRET_KEY=change_me
 REMOTE_LOG_URL=
 API_GATEWAY_METRICS_PORT=9001
@@ -15,3 +15,6 @@ REDIS_DB=0
 RATE_LIMIT_PER_MINUTE=100
 RABBITMQ_URL=amqp://guest:guest@localhost:5672/
 ALPHA_VANTAGE_KEY=demo
+BINANCE_API_KEY=demo
+BINANCE_API_SECRET=demo
+IBKR_API_KEY=demo

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# .gitignore v0.2.11 (2025-08-20)
+# .gitignore v0.2.12 (2025-08-19)
 # Python artifacts
 __pycache__/
 *.py[cod]
@@ -35,3 +35,4 @@ db/data/
 logs/
 backtester/reports/
 perf/
+execution-engine/logs/

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.19
+# Changelog v0.6.20
 
 ## 2025-02-14
 - Introduced user manual revision with installation, usage, architecture and troubleshooting sections.
@@ -65,6 +65,11 @@
  - Added Alpha Vantage bond and commodity fetchers with message bus integration.
  - Enabled TimescaleDB extension and converted `prices` to a hypertable with migration and schema checks.
  - Updated install script and documentation for TimescaleDB.
+
+- Implemented real broker adapters using config-driven API keys and robust error handling.
+- Order handler now stores orders and executions in the database with Redis caching.
+- Updated log creation scripts and `.gitignore` for execution-engine order logs.
+- Added unit tests for adapters and order handler using mocked requests and fakeredis.
 
 ## 2025-08-18
 - Added initial development tasks outline.

--- a/changelog_2025-08-19.md
+++ b/changelog_2025-08-19.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.17
+# Changelog v0.6.18
 
 ## 2025-08-19
 - Added shared monitoring utilities providing JSON logging, Prometheus metrics and OpenTelemetry traces.
@@ -38,6 +38,11 @@
 - Reconciled development_tasks with repository state, marking tasks complete and cross-linking with user manual.
 
 - Implemented goals, actions and orders endpoints with a repository layer and admin-only mutations, and documented new APIs.
+
+- Implemented real broker adapters using config-driven API keys and robust error handling.
+- Order handler now stores orders and executions in the database with Redis caching.
+- Updated log creation scripts and `.gitignore` for execution-engine order logs.
+- Added unit tests for adapters and order handler using mocked requests and fakeredis.
 
 - Fixed service consumer imports by dropping hyphenated module paths.
 - Addressed Bandit warnings with safe subprocess calls, test skips, and enhanced logging.

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,4 +1,4 @@
-"""Configuration loader v0.1.3 (2025-08-19)"""
+"""Configuration loader v0.1.4 (2025-08-19)"""
 from dataclasses import dataclass
 from dotenv import load_dotenv
 import os
@@ -23,6 +23,9 @@ class Settings:
     rate_limit_per_minute: int = int(os.getenv("RATE_LIMIT_PER_MINUTE", "100"))
     rabbitmq_url: str = os.getenv("RABBITMQ_URL", "amqp://guest:guest@localhost:5672/")
     alpha_vantage_key: str = os.getenv("ALPHA_VANTAGE_KEY", "demo")
+    binance_api_key: str = os.getenv("BINANCE_API_KEY", "demo")
+    binance_api_secret: str = os.getenv("BINANCE_API_SECRET", "demo")
+    ibkr_api_key: str = os.getenv("IBKR_API_KEY", "demo")
 
 
 settings = Settings()

--- a/execution-engine/adapters/base.py
+++ b/execution-engine/adapters/base.py
@@ -1,9 +1,11 @@
-"""Base adapter interface v0.1.0"""
+"""Base adapter interface v0.2.0 (2025-08-19)"""
 
 from typing import Dict, Protocol
 
+
 class BrokerAdapter(Protocol):
     """Adapter interface for brokers."""
-    def place_order(self, order: Dict) -> str:
-        """Place an order and return broker-specific id."""
+
+    def place_order(self, order: Dict) -> Dict:
+        """Place an order and return broker-specific details."""
         ...

--- a/execution-engine/adapters/binance.py
+++ b/execution-engine/adapters/binance.py
@@ -1,10 +1,34 @@
-"""Binance adapter v0.1.0"""
+"""Binance adapter v0.2.0 (2025-08-19)"""
 
 from typing import Dict
+import requests
 
+from config import settings
 from .base import BrokerAdapter
+
 
 class BinanceAdapter:
     """Binance adapter."""
-    def place_order(self, order: Dict) -> str:  # pragma: no cover - placeholder
-        return "BINANCE_ORDER_ID"
+
+    def __init__(self, base_url: str = "https://api.binance.com") -> None:
+        self.base_url = base_url
+        self.api_key = settings.binance_api_key
+
+    def place_order(self, order: Dict) -> Dict:
+        """Place an order via Binance REST API."""
+        try:
+            resp = requests.post(
+                f"{self.base_url}/api/v3/order",
+                headers={"X-MBX-APIKEY": self.api_key},
+                json=order,
+                timeout=5,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return {
+                "order_id": str(data.get("orderId")),
+                "price": data.get("fills", [{}])[0].get("price"),
+                "qty": data.get("executedQty"),
+            }
+        except requests.RequestException as exc:  # pragma: no cover - network errors
+            raise RuntimeError(f"Binance order failed: {exc}") from exc

--- a/execution-engine/adapters/ibkr.py
+++ b/execution-engine/adapters/ibkr.py
@@ -1,10 +1,34 @@
-"""IBKR adapter v0.1.0"""
+"""IBKR adapter v0.2.0 (2025-08-19)"""
 
 from typing import Dict
+import requests
 
+from config import settings
 from .base import BrokerAdapter
+
 
 class IBKRAdapter:
     """Interactive Brokers adapter."""
-    def place_order(self, order: Dict) -> str:  # pragma: no cover - placeholder
-        return "IBKR_ORDER_ID"
+
+    def __init__(self, base_url: str = "https://paper-api.interactivebrokers.com") -> None:
+        self.base_url = base_url
+        self.api_key = settings.ibkr_api_key
+
+    def place_order(self, order: Dict) -> Dict:
+        """Place an order via IBKR REST API."""
+        try:
+            resp = requests.post(
+                f"{self.base_url}/v1/orders",
+                headers={"IBKR-APIKEY": self.api_key},
+                json=order,
+                timeout=5,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            return {
+                "order_id": str(data.get("id")),
+                "price": data.get("price"),
+                "qty": data.get("qty"),
+            }
+        except requests.RequestException as exc:  # pragma: no cover - network errors
+            raise RuntimeError(f"IBKR order failed: {exc}") from exc

--- a/execution-engine/order_handler.py
+++ b/execution-engine/order_handler.py
@@ -1,29 +1,89 @@
-"""Order handler v0.1.0"""
+"""Order handler v0.2.0 (2025-08-19)"""
 
 import json
 import logging
 from pathlib import Path
 from typing import Dict
 
+import psycopg2
+import redis
+
+from config import settings
 from .adapters import IBKRAdapter, BinanceAdapter, BrokerAdapter
+
 
 class OrderHandler:
     """Broker-agnostic order handler."""
-    def __init__(self, log_path: str = "execution-engine/logs/orders.log") -> None:
+
+    def __init__(
+        self,
+        log_path: str = "execution-engine/logs/orders.log",
+        redis_client: redis.Redis | None = None,
+    ) -> None:
         Path(log_path).parent.mkdir(parents=True, exist_ok=True)
         self.logger = logging.getLogger("order_handler")
         self.logger.setLevel(logging.INFO)
         handler = logging.FileHandler(log_path)
-        handler.setFormatter(logging.Formatter('%(message)s'))
+        handler.setFormatter(logging.Formatter("%(message)s"))
         self.logger.addHandler(handler)
         self.adapters: Dict[str, BrokerAdapter] = {
             "ibkr": IBKRAdapter(),
             "binance": BinanceAdapter(),
         }
+        self.redis = redis_client or redis.Redis(
+            host=settings.redis_host,
+            port=settings.redis_port,
+            db=settings.redis_db,
+        )
 
     def place_order(self, broker: str, order: Dict) -> str:
         adapter = self.adapters[broker.lower()]
-        order_id = adapter.place_order(order)
-        log_entry = {"broker": broker, "order_id": order_id, "order": order}
+        result = adapter.place_order(order)
+        log_entry = {"broker": broker, "order_id": result["order_id"], "order": order}
         self.logger.info(json.dumps(log_entry))
-        return order_id
+        self.redis.set(f"order:{result['order_id']}", json.dumps(result))
+        try:
+            with psycopg2.connect(
+                host=settings.db_host,
+                port=settings.db_port,
+                dbname=settings.db_name,
+                user=settings.db_user,
+                password=settings.db_pass,
+            ) as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        INSERT INTO orders (account_id, symbol, side, qty, type, limit_price, status, reason, sl, tp)
+                        VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                        RETURNING id
+                        """,
+                        (
+                            order.get("account_id"),
+                            order.get("symbol"),
+                            order.get("side"),
+                            order.get("qty"),
+                            order.get("type"),
+                            order.get("limit_price"),
+                            order.get("status"),
+                            order.get("reason"),
+                            order.get("sl"),
+                            order.get("tp"),
+                        ),
+                    )
+                    db_order_id = cur.fetchone()[0]
+                    if result.get("price") and result.get("qty"):
+                        cur.execute(
+                            """
+                            INSERT INTO executions (order_id, price, qty, fee, ts)
+                            VALUES (%s,%s,%s,%s,NOW())
+                            """,
+                            (
+                                db_order_id,
+                                result.get("price"),
+                                result.get("qty"),
+                                result.get("fee"),
+                            ),
+                        )
+        except Exception as exc:  # pragma: no cover - database issues
+            raise RuntimeError(f"Failed to persist order: {exc}") from exc
+        return result["order_id"]

--- a/execution-engine/tests/test_adapters.py
+++ b/execution-engine/tests/test_adapters.py
@@ -1,0 +1,59 @@
+import importlib
+import importlib.util
+from pathlib import Path
+import sys
+import pytest
+import requests
+
+ROOT = Path(__file__).resolve().parents[2]
+PKG_PATH = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+spec = importlib.util.spec_from_file_location(
+    "execution_engine", PKG_PATH / "__init__.py", submodule_search_locations=[str(PKG_PATH)]
+)
+package = importlib.util.module_from_spec(spec)
+sys.modules["execution_engine"] = package
+spec.loader.exec_module(package)
+
+binance_mod = importlib.import_module("execution_engine.adapters.binance")
+ibkr_mod = importlib.import_module("execution_engine.adapters.ibkr")
+BinanceAdapter = binance_mod.BinanceAdapter
+IBKRAdapter = ibkr_mod.IBKRAdapter
+
+
+class DummyResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if not (200 <= self.status_code < 300):
+            raise requests.HTTPError("error")
+
+    def json(self):
+        return self._payload
+
+
+def test_binance_adapter_success(monkeypatch):
+    adapter = BinanceAdapter()
+
+    def fake_post(url, headers, json, timeout):
+        assert "X-MBX-APIKEY" in headers
+        return DummyResponse({"orderId": "1", "executedQty": "1", "fills": [{"price": "10"}]})
+
+    monkeypatch.setattr(binance_mod.requests, "post", fake_post)
+    result = adapter.place_order({"symbol": "BTCUSDT"})
+    assert result["order_id"] == "1"
+    assert result["price"] == "10"
+
+
+def test_ibkr_adapter_error(monkeypatch):
+    adapter = IBKRAdapter()
+
+    def fake_post(*args, **kwargs):
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(ibkr_mod.requests, "post", fake_post)
+    with pytest.raises(RuntimeError):
+        adapter.place_order({"symbol": "AAPL"})

--- a/execution-engine/tests/test_order_handler.py
+++ b/execution-engine/tests/test_order_handler.py
@@ -1,0 +1,74 @@
+import importlib
+import importlib.util
+from pathlib import Path
+import sys
+import fakeredis
+
+ROOT = Path(__file__).resolve().parents[2]
+PKG_PATH = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+spec = importlib.util.spec_from_file_location(
+    "execution_engine", PKG_PATH / "__init__.py", submodule_search_locations=[str(PKG_PATH)]
+)
+package = importlib.util.module_from_spec(spec)
+sys.modules["execution_engine"] = package
+spec.loader.exec_module(package)
+
+order_handler_mod = importlib.import_module("execution_engine.order_handler")
+OrderHandler = order_handler_mod.OrderHandler
+
+
+class DummyAdapter:
+    def place_order(self, order):
+        return {"order_id": "abc", "price": 10, "qty": 1}
+
+
+class FakeCursor:
+    def __init__(self, executed):
+        self.executed = executed
+
+    def execute(self, sql, params):
+        self.executed.append((sql.strip(), params))
+
+    def fetchone(self):
+        return [1]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+class FakeConn:
+    def __init__(self, executed):
+        self.executed = executed
+
+    def cursor(self):
+        return FakeCursor(self.executed)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+def test_order_persistence(monkeypatch):
+    executed = []
+
+    def fake_connect(**kwargs):
+        return FakeConn(executed)
+
+    monkeypatch.setattr(order_handler_mod.psycopg2, "connect", fake_connect)
+
+    redis_client = fakeredis.FakeRedis()
+    handler = OrderHandler(redis_client=redis_client)
+    handler.adapters["binance"] = DummyAdapter()
+
+    order_id = handler.place_order("binance", {"symbol": "BTC", "qty": 1})
+    assert order_id == "abc"
+    assert redis_client.get("order:abc") is not None
+    assert any("INSERT INTO orders" in sql for sql, _ in executed)
+    assert any("INSERT INTO executions" in sql for sql, _ in executed)

--- a/tools/log_create.sh
+++ b/tools/log_create.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# log directory creator v0.6.7 (2025-08-20)
+# log directory creator v0.6.8 (2025-08-19)
 set -e
 mkdir -p logs
 mkdir -p logs/containers
@@ -7,6 +7,7 @@ mkdir -p logs/analytics
 mkdir -p backtester/reports
 mkdir -p ui/.next
 mkdir -p perf
+mkdir -p execution-engine/logs
 touch logs/orchestrator.log
 touch logs/data-ingestion.log
 touch logs/strategy-engine.log
@@ -14,3 +15,4 @@ touch logs/risk-engine.log
 touch logs/execution-engine.log
 touch logs/messaging.log
 touch logs/feasibility-calculator.log
+touch execution-engine/logs/orders.log

--- a/tools/log_create_win.cmd
+++ b/tools/log_create_win.cmd
@@ -1,11 +1,12 @@
 @echo off
-REM log directory creator v0.6.7 (2025-08-20)
+REM log directory creator v0.6.8 (2025-08-19)
 mkdir logs 2>nul
 mkdir logs\containers 2>nul
 mkdir logs\analytics 2>nul
 mkdir backtester\reports 2>nul
 mkdir ui\.next 2>nul
 mkdir perf 2>nul
+mkdir execution-engine\logs 2>nul
 type nul > logs\orchestrator.log
 type nul > logs\data-ingestion.log
 type nul > logs\strategy-engine.log
@@ -13,3 +14,4 @@ type nul > logs\risk-engine.log
 type nul > logs\execution-engine.log
 type nul > logs\messaging.log
 type nul > logs\feasibility-calculator.log
+type nul > execution-engine\logs\orders.log

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.20
+# User Manual v0.6.21
 
 Date: 2025-08-19
 
@@ -8,7 +8,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Refer to [development_tasks.md](development_tasks.md) for the latest task status.
 
 ## Installation
-- Copy `.env.example` to `.env` and adjust values as needed, including `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, `RATE_LIMIT_PER_MINUTE` and `ALPHA_VANTAGE_KEY`.
+- Copy `.env.example` to `.env` and adjust values as needed, including `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, `RATE_LIMIT_PER_MINUTE`, `ALPHA_VANTAGE_KEY`, `BINANCE_API_KEY`, `BINANCE_API_SECRET` and `IBKR_API_KEY`.
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
 - Each service provides `install.sh` and `remove.sh` scripts.
@@ -27,6 +27,8 @@ This document will evolve into a comprehensive encyclopedia for the project.
  - The orchestrator sequentially dispatches `data_fetch`, `strategy_compute`, `risk_adjust` and `order_dispatch` events.
  - `data_fetch` covers equities, bonds and commodities via Alpha Vantage fetchers.
 - Data ingestion, strategy-engine, risk-engine and execution-engine consume these events from RabbitMQ.
+- Execution-engine adapters pull API keys from configuration (`BINANCE_API_KEY`, `BINANCE_API_SECRET`, `IBKR_API_KEY`). Orders
+  are persisted to `orders` and `executions` tables, cached in Redis and logged to `execution-engine/logs/orders.log`.
 - Pass `--install` or `--remove` to service scripts for setup and teardown.
 - The UI supports French and English; append `/en` to URLs to switch to English.
 - Visualize aggregated metrics via the `/analytics` endpoint or the UI analytics page.


### PR DESCRIPTION
## Summary
- implement Binance and IBKR adapters with config API keys and error handling
- persist orders and executions to database with Redis caching in order handler
- add tests using mocked requests and fakeredis

## Testing
- `cd execution-engine/tests && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4ba7d32f4832c807df09fa63e87fa