### PR TITLE
feat: enrich backtester with DB pricing and KPIs

### DIFF
--- a/admin/db_check.php
+++ b/admin/db_check.php
@@ -1,5 +1,5 @@
 <?php
-// db_check.php v0.1.3 (2025-08-19)
+// db_check.php v0.1.4 (2025-08-19)
 $expectedVersion = 'v0.1.1';
 $dsn = sprintf('pgsql:host=%s;port=%s;dbname=%s',
     getenv('DB_HOST') ?: 'localhost',
@@ -50,6 +50,16 @@ $cols = $stmt->fetchAll(PDO::FETCH_COLUMN);
 foreach ($metricsColumns as $col) {
     if (!in_array($col, $cols)) {
         echo "Missing column in metrics_daily: $col\n";
+        exit(1);
+    }
+}
+
+$backtestColumns = ['id','cfg_json','start','end','kpis_json','report_path'];
+$stmt = $pdo->query("SELECT column_name FROM information_schema.columns WHERE table_name='backtests'");
+$cols = $stmt->fetchAll(PDO::FETCH_COLUMN);
+foreach ($backtestColumns as $col) {
+    if (!in_array($col, $cols)) {
+        echo "Missing column in backtests: $col\n";
         exit(1);
     }
 }

--- a/backtester/__init__.py
+++ b/backtester/__init__.py
@@ -1,2 +1,2 @@
-"""backtester service v0.3.2 (2025-08-20)"""
-__version__ = "0.3.2"
+"""backtester service v0.4.0 (2025-08-19)"""
+__version__ = "0.4.0"

--- a/backtester/cli.py
+++ b/backtester/cli.py
@@ -1,11 +1,24 @@
 #!/usr/bin/env python3
-"""backtester CLI v0.3.2 (2025-08-20)"""
+"""backtester CLI v0.4.0 (2025-08-19)"""
 import argparse
+import base64
 import json
 import os
-import subprocess  # nosec B404
 import shutil
+import subprocess  # nosec B404
+import sys
 from datetime import datetime
+from io import BytesIO
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import psycopg2
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from config import settings
 
 REPORT_DIR = os.path.join(os.path.dirname(__file__), "reports")
 
@@ -26,6 +39,54 @@ def run_backtest(config_path: str, start_date: str, end_date: str, output_path: 
     with open(config_path, "r", encoding="utf-8") as f:
         config = json.load(f)
 
+    symbols = config.get("symbols")
+    if not symbols:
+        raise ValueError("config must include 'symbols'")
+    capital = float(config.get("initial_capital", 10_000))
+
+    conn = psycopg2.connect(
+        host=settings.db_host,
+        port=settings.db_port,
+        dbname=settings.db_name,
+        user=settings.db_user,
+        password=settings.db_pass,
+    )
+
+    prices: dict[str, pd.Series] = {}
+    for sym in symbols:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT ts, c FROM prices WHERE symbol=%s AND ts BETWEEN %s AND %s ORDER BY ts",
+                (sym, start_date, end_date),
+            )
+            rows = cur.fetchall()
+        if not rows:
+            raise ValueError(f"No price data for {sym}")
+        df = pd.DataFrame(rows, columns=["ts", sym]).set_index("ts")
+        prices[sym] = df[sym]
+    price_df = pd.DataFrame(prices).sort_index()
+    returns = price_df.pct_change().dropna()
+    weights = np.repeat(1 / len(symbols), len(symbols))
+    portfolio_returns = (returns * weights).sum(axis=1)
+    equity = (1 + portfolio_returns).cumprod() * capital
+
+    days = (equity.index[-1] - equity.index[0]).days or 1
+    years = days / 365.25
+    cagr = (equity.iloc[-1] / capital) ** (1 / years) - 1
+    sharpe = np.sqrt(252) * portfolio_returns.mean() / (portfolio_returns.std() or 1)
+    running_max = equity.cummax()
+    drawdown = (equity - running_max) / running_max
+    max_dd = drawdown.min()
+    kpis = {"CAGR": cagr, "Sharpe": sharpe, "MaxDrawdown": max_dd}
+
+    fig, ax = plt.subplots()
+    equity.plot(ax=ax)
+    ax.set_title("Equity Curve")
+    buf = BytesIO()
+    fig.savefig(buf, format="png")
+    plt.close(fig)
+    img_b64 = base64.b64encode(buf.getvalue()).decode()
+
     os.makedirs(REPORT_DIR, exist_ok=True)
     if output_path is None:
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -36,16 +97,27 @@ def run_backtest(config_path: str, start_date: str, end_date: str, output_path: 
         f"<p>Strategy: {config.get('name', 'unknown')}</p>"
         f"<p>Start: {start_date}</p>"
         f"<p>End: {end_date}</p>"
-        "</body></html>"
+        "<h2>KPIs</h2><ul>"
+        + "".join(f"<li>{k}: {v:.4f}</li>" for k, v in kpis.items())
+        + "</ul>"
+        f"<img src='data:image/png;base64,{img_b64}' alt='Equity Curve'/></body></html>"
     )
 
     with open(output_path, "w", encoding="utf-8") as out:
         out.write(html)
     print(f"Report generated at {output_path}")
 
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO backtests (cfg_json, start, end, kpis_json, report_path) VALUES (%s,%s,%s,%s,%s)",
+            (json.dumps(config), start_date, end_date, json.dumps(kpis), output_path),
+        )
+        conn.commit()
+    conn.close()
+
 
 def main():
-    parser = argparse.ArgumentParser(description="Backtester controller v0.3.2")
+    parser = argparse.ArgumentParser(description="Backtester controller v0.4.0")
     parser.add_argument("--install", action="store_true", help="Install backtester service")
     parser.add_argument("--remove", action="store_true", help="Remove backtester service")
     parser.add_argument("--config", help="Path to strategy config JSON")

--- a/backtester/install.sh
+++ b/backtester/install.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# backtester installer v0.3.2 (2025-08-20)
+# backtester installer v0.4.0 (2025-08-19)
 echo "Installing backtester service..."
 mkdir -p "$(dirname "$0")/reports"

--- a/backtester/remove.sh
+++ b/backtester/remove.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# backtester removal v0.3.2 (2025-08-20)
+# backtester removal v0.4.0 (2025-08-19)
 echo "Removing backtester service..."
 rm -rf "$(dirname "$0")/reports"

--- a/backtester/requirements.txt
+++ b/backtester/requirements.txt
@@ -1,4 +1,4 @@
-# requirements.txt v0.1.0 (2025-08-20)
+# requirements.txt v0.1.1 (2025-08-19)
 requests>=2.31.0
 fastapi>=0.110.0
 uvicorn>=0.29.0
@@ -13,3 +13,5 @@ opentelemetry-sdk>=1.24.0
 python-dotenv>=1.0.1
 redis>=5.0.0
 pika>=1.3.2
+pandas>=2.2.2
+matplotlib>=3.10.5

--- a/backtester/tests/test_cli.py
+++ b/backtester/tests/test_cli.py
@@ -1,33 +1,77 @@
 # nosec
-"""Tests for backtester CLI v0.3.1 (2025-08-19)"""
+"""Tests for backtester CLI v0.4.0 (2025-08-19)"""
 import json
 import subprocess  # nosec B404
 import sys
+from datetime import datetime
 from pathlib import Path
+
+from backtester import cli as cli_mod
 
 CLI_PATH = Path(__file__).resolve().parents[1] / "cli.py"
 
 
-def test_generate_report(tmp_path):
+def test_generate_report(tmp_path, monkeypatch):
     config_path = tmp_path / "config.json"
-    config_path.write_text(json.dumps({"name": "TestStrategy"}))
+    config_path.write_text(json.dumps({
+        "name": "TestStrategy",
+        "symbols": ["AAPL"],
+        "initial_capital": 1000,
+    }))
     output_path = tmp_path / "report.html"
-    subprocess.run([
-        sys.executable,
-        str(CLI_PATH),
-        "--config",
-        str(config_path),
-        "--start-date",
-        "2024-01-01",
-        "--end-date",
-        "2024-06-01",
-        "--output",
-        str(output_path),
-    ], check=True)  # nosec B603
+
+    class FakeCursor:
+        def __init__(self, conn):
+            self.conn = conn
+            self.data = []
+
+        def execute(self, query, params):
+            if query.strip().startswith("SELECT"):
+                self.data = [
+                    (datetime(2024, 1, 1), 100.0),
+                    (datetime(2024, 1, 2), 101.0),
+                    (datetime(2024, 1, 3), 102.0),
+                ]
+            else:
+                self.conn.inserted = params
+
+        def fetchall(self):
+            return self.data
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeConn:
+        def __init__(self):
+            self.inserted = None
+
+        def cursor(self):
+            return FakeCursor(self)
+
+        def commit(self):
+            return None
+
+        def close(self):
+            return None
+
+    fake_conn = FakeConn()
+
+    def fake_connect(*args, **kwargs):  # nosec
+        return fake_conn
+
+    monkeypatch.setattr(cli_mod.psycopg2, "connect", fake_connect)
+    cli_mod.run_backtest(str(config_path), "2024-01-01", "2024-01-03", str(output_path))
+
     assert output_path.exists()  # nosec
     content = output_path.read_text()
-    assert "Backtest Report" in content  # nosec
-    assert "TestStrategy" in content  # nosec
+    assert "CAGR" in content  # nosec
+    assert "<img" in content  # nosec
+
+    kpis = json.loads(fake_conn.inserted[3])
+    assert "CAGR" in kpis  # nosec
 
 
 def test_install_and_remove(tmp_path):

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.20
+# Changelog v0.6.21
 
 ## 2025-02-14
 - Introduced user manual revision with installation, usage, architecture and troubleshooting sections.
@@ -113,6 +113,10 @@
 - Added backtester CLI for HTML reports with install/remove commands, tests, and report directories.
 - Updated user manual and log creation scripts; ignored report outputs.
 
+- Implemented database-driven price loading and portfolio simulation in backtester CLI with KPI charts.
+- Stored backtest metrics in the `backtests` table and expanded schema checks.
+- Added pandas and matplotlib dependencies with version bumps and updated tests and user manual.
+
 ## 2025-08-20
 - Added Next.js internationalization with French default and English fallback locales.
 - Externalized UI strings to translation files with locale install/remove scripts.
@@ -123,4 +127,5 @@
 - Introduced Monte Carlo simulation utilities in strategy-engine with probability-of-hitting calculations.
 - Core and satellite strategies now derive signals from market data, adjust risk via the risk engine, and justify allocations through `explain()`.
 - Extended strategy interface with `explain()` and added tests and documentation for dynamic weights.
+
 

--- a/changelog_2025-08-19.md
+++ b/changelog_2025-08-19.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.18
+# Changelog v0.6.19
 
 ## 2025-08-19
 - Added shared monitoring utilities providing JSON logging, Prometheus metrics and OpenTelemetry traces.
@@ -51,6 +51,9 @@
   `messaging.log` path with version bumps across orchestrator and dependent services.
 
 - Added per-service `requirements.txt` files with updated Dockerfiles and install scripts to eliminate build warnings.
+
+- Implemented database-driven price loading and portfolio simulation in backtester CLI with KPI charts and metrics storage.
+- Expanded `admin/db_check.php` to validate `backtests` columns and updated documentation with new dependencies.
 
 ## 2025-08-18
 - Added initial development tasks outline.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# requirements.txt v0.3.2 (2025-08-20)
+# requirements.txt v0.3.3 (2025-08-19)
 
 # Runtime dependencies
 requests>=2.31.0
@@ -10,6 +10,8 @@ yfinance>=0.2.40
 ccxt>=4.0.0
 psycopg2-binary>=2.9.9
 numpy>=1.26.0
+pandas>=2.2.2
+matplotlib>=3.10.5
 prometheus-client>=0.20.0
 opentelemetry-sdk>=1.24.0
 python-dotenv>=1.0.1

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.21
+# User Manual v0.6.22
 
 Date: 2025-08-19
 
@@ -33,6 +33,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - The UI supports French and English; append `/en` to URLs to switch to English.
 - Visualize aggregated metrics via the `/analytics` endpoint or the UI analytics page.
 - The feasibility-calculator service exposes `/feasibility` to estimate CAGR, daily returns and probability of hitting a target based on capital, goal, deadline and risk profile.
+- The backtester CLI loads prices from the database, simulates equal-weight portfolios, computes KPIs (CAGR, Sharpe, max drawdown), embeds equity charts in HTML reports and records metrics in the `backtests` table.
 
 ### Strategy Engine
 - `strategy-engine` now provides `simulation.py` for Monte Carlo path generation and probability-of-hitting analysis.

--- a/user_manual_2025-08-19.md
+++ b/user_manual_2025-08-19.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.16
+# User Manual v0.6.17
 
 Date: 2025-08-19
 
@@ -97,6 +97,7 @@ Each service now includes a `requirements.txt` file to facilitate Docker builds 
 - Run `python backtester/cli.py --config config.json --start-date 2024-01-01 --end-date 2024-06-01`.
 - Use `--output` to specify report path; defaults to `backtester/reports`.
 - Flags: `--install` to prepare report directory, `--remove` to clean it`.
+- The CLI now pulls prices from the database, simulates equal-weight portfolios, outputs KPIs (CAGR, Sharpe, max drawdown) with embedded charts and writes metrics to the `backtests` table.
 
 ## Architecture
 - See README for initial specification.


### PR DESCRIPTION
## Summary
- simulate portfolio returns by loading prices from the database and generate KPI charts in the backtester CLI
- persist backtest metrics to the `backtests` table with schema validation updates
- document new workflow and add pandas/matplotlib dependencies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4bf423c6c832c94c5f10b88eed3f2