### PR TITLE
Add risk stress test endpoint and migration

### DIFF
--- a/admin/db_check.php
+++ b/admin/db_check.php
@@ -1,6 +1,6 @@
 <?php
-// db_check.php v0.1.4 (2025-08-19)
-$expectedVersion = 'v0.1.1';
+// db_check.php v0.1.5 (2025-08-19)
+$expectedVersion = 'v0.1.2';
 $dsn = sprintf('pgsql:host=%s;port=%s;dbname=%s',
     getenv('DB_HOST') ?: 'localhost',
     getenv('DB_PORT') ?: '5432',
@@ -9,7 +9,7 @@ $user = getenv('DB_USER') ?: 'postgres';
 $pass = getenv('DB_PASS') ?: '';
 $requiredTables = [
     'users','goals','accounts','portfolios','positions','orders',
-    'executions','prices','signals','actions','risk_limits','metrics_daily','backtests'
+    'executions','prices','signals','actions','risk_limits','metrics_daily','backtests','risk_stress_results'
 ];
 $priceColumns = ['symbol','venue','ts','o','h','l','c','v'];
 try {
@@ -60,6 +60,15 @@ $cols = $stmt->fetchAll(PDO::FETCH_COLUMN);
 foreach ($backtestColumns as $col) {
     if (!in_array($col, $cols)) {
         echo "Missing column in backtests: $col\n";
+        exit(1);
+    }
+}
+$stressColumns = ['id','scenario','metric','created_at'];
+$stmt = $pdo->query("SELECT column_name FROM information_schema.columns WHERE table_name='risk_stress_results'");
+$cols = $stmt->fetchAll(PDO::FETCH_COLUMN);
+foreach ($stressColumns as $col) {
+    if (!in_array($col, $cols)) {
+        echo "Missing column in risk_stress_results: $col\n";
         exit(1);
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.26
+# Changelog v0.6.27
 
 ## 2025-02-14
 - Introduced user manual revision with installation, usage, architecture and troubleshooting sections.
@@ -84,6 +84,7 @@
 - Documented new metrics endpoints in the user manual.
 - Updated development tasks with new deliverables from the README and bumped README to v0.1.5 with current date linkage.
 - Replaced insecure asserts in execution-engine tests and bound feasibility-calculator to localhost to satisfy Bandit.
+- Added historical and hypothetical stress test endpoint `/risk/stress` with persistence, migrations and documentation.
 
 ## 2025-08-18
 - Added initial development tasks outline.

--- a/changelog_2025-08-19.md
+++ b/changelog_2025-08-19.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.22
+# Changelog v0.6.23
 
 ## 2025-08-19
 - Added shared monitoring utilities providing JSON logging, Prometheus metrics and OpenTelemetry traces.
@@ -62,6 +62,8 @@
 - Implemented database-driven price loading and portfolio simulation in backtester CLI with KPI charts and metrics storage.
 - Expanded `admin/db_check.php` to validate `backtests` columns and updated documentation with new dependencies.
 - Silenced npm http-proxy warning in UI tests via `.npmrc` loglevel setting.
+
+- Added historical and hypothetical stress test endpoint `/risk/stress` with persistence, migrations and documentation.
 
 
 ## 2025-08-18

--- a/db/migrations/015_create_risk_stress_results.sql
+++ b/db/migrations/015_create_risk_stress_results.sql
@@ -1,0 +1,7 @@
+-- risk_stress_results table migration v0.1.0
+CREATE TABLE IF NOT EXISTS risk_stress_results (
+    id SERIAL PRIMARY KEY,
+    scenario TEXT NOT NULL,
+    metric JSONB NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# requirements.txt v0.3.3 (2025-08-19)
+# requirements.txt v0.3.4 (2025-08-19)
 
 # Runtime dependencies
 requests>=2.31.0
@@ -11,6 +11,7 @@ ccxt>=4.0.0
 psycopg2-binary>=2.9.9
 numpy>=1.26.0
 pandas>=2.2.2
+scipy>=1.12.0
 matplotlib>=3.10.5
 prometheus-client>=0.20.0
 opentelemetry-sdk>=1.24.0

--- a/risk-engine/__init__.py
+++ b/risk-engine/__init__.py
@@ -1,4 +1,4 @@
-"""risk-engine service v0.4.4 (2025-08-19)"""
-__version__ = "0.4.4"
+"""risk-engine service v0.4.5 (2025-08-19)"""
+__version__ = "0.4.5"
 
 from .engine import volatility_target, var_es, kelly_fraction

--- a/risk-engine/install.sh
+++ b/risk-engine/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# risk-engine installer v0.4.4 (2025-08-19)
+# risk-engine installer v0.4.5 (2025-08-19)
 set -e
 
 echo "Installing risk-engine service..."

--- a/risk-engine/main.py
+++ b/risk-engine/main.py
@@ -1,13 +1,72 @@
 #!/usr/bin/env python3
-"""risk-engine consumer v0.4.3 (2025-08-19)"""
+"""risk-engine service v0.4.5 (2025-08-19)"""
+
 import argparse
+import json
 import os
 import subprocess  # nosec B404
+from typing import List
 
-from common.monitoring import setup_logging
+import psycopg2
+from fastapi import FastAPI, Request
+from pydantic import BaseModel
+
+from common.monitoring import setup_logging, setup_metrics, setup_tracer
 from config import settings
 from messaging import EventConsumer
 from engine import volatility_target
+from stress_tests import historical_scenario, hypothetical_scenario
+
+app = FastAPI(title="risk-engine", version="0.3.0")
+logger = setup_logging("risk-engine", remote_url=settings.remote_log_url)
+REQUEST_COUNT = setup_metrics("risk-engine", port=settings.risk_engine_metrics_port)
+tracer = setup_tracer("risk-engine")
+
+
+@app.middleware("http")
+async def add_version_header(request: Request, call_next):
+    with tracer.start_as_current_span(request.url.path):
+        response = await call_next(request)
+    REQUEST_COUNT.inc()
+    response.headers["X-API-Version"] = "v0.3.0"
+    return response
+
+
+class StressRequest(BaseModel):
+    prices: List[float]
+    shocks: List[float]
+
+
+class StressResponse(BaseModel):
+    historical: List[float]
+    hypothetical: List[float]
+
+
+def _store_result(scenario: str, data: dict) -> None:
+    try:
+        with psycopg2.connect(
+            host=settings.db_host,
+            port=settings.db_port,
+            dbname=settings.db_name,
+            user=settings.db_user,
+            password=settings.db_pass,
+        ) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO risk_stress_results (scenario, metric) VALUES (%s, %s)",
+                    (scenario, json.dumps(data)),
+                )
+    except Exception as exc:  # pragma: no cover - log error path
+        logger.error("DB insert failed: %s", exc)
+
+
+@app.post("/risk/stress", response_model=StressResponse)
+def stress(payload: StressRequest) -> StressResponse:
+    historical = historical_scenario(payload.prices)
+    hypothetical = hypothetical_scenario(payload.prices, payload.shocks)
+    _store_result("historical", {"prices": payload.prices, "result": historical})
+    _store_result("hypothetical", {"shocks": payload.shocks, "result": hypothetical})
+    return StressResponse(historical=historical, hypothetical=hypothetical)
 
 
 def install_service():
@@ -31,10 +90,12 @@ def handle_event(message: dict) -> None:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="risk-engine consumer v0.4.3")
+    parser = argparse.ArgumentParser(description="risk-engine consumer v0.4.5")
     parser.add_argument("--install", action="store_true", help="Install risk-engine service")
     parser.add_argument("--remove", action="store_true", help="Remove risk-engine service")
-    parser.add_argument("--log-path", default=os.path.join("logs", "risk-engine.log"), help="Path to log file")
+    parser.add_argument(
+        "--log-path", default=os.path.join("logs", "risk-engine.log"), help="Path to log file"
+    )
     args = parser.parse_args()
 
     if args.install:

--- a/risk-engine/remove.sh
+++ b/risk-engine/remove.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# risk-engine removal v0.4.4 (2025-08-19)
+# risk-engine removal v0.4.5 (2025-08-19)
 set -e
 
 echo "Removing risk-engine service..."

--- a/risk-engine/requirements.txt
+++ b/risk-engine/requirements.txt
@@ -1,4 +1,4 @@
-# requirements.txt v0.1.0 (2025-08-19)
+# requirements.txt v0.1.1 (2025-08-19)
 requests>=2.31.0
 fastapi>=0.110.0
 uvicorn>=0.29.0
@@ -8,6 +8,8 @@ yfinance>=0.2.40
 ccxt>=4.0.0
 psycopg2-binary>=2.9.9
 numpy>=1.26.0
+scipy>=1.12.0
+pandas>=2.2.2
 prometheus-client>=0.20.0
 opentelemetry-sdk>=1.24.0
 python-dotenv>=1.0.1

--- a/risk-engine/stress_tests.py
+++ b/risk-engine/stress_tests.py
@@ -1,0 +1,20 @@
+"""Stress test utilities v0.1.0 (2025-08-19)"""
+from __future__ import annotations
+from typing import List
+import numpy as np
+
+
+def historical_scenario(prices: List[float]) -> List[float]:
+    """Apply worst historical return to all prices."""
+    if len(prices) < 2:
+        return prices
+    returns = np.diff(prices) / np.array(prices[:-1])
+    shock = returns.min()
+    return [p * (1 + shock) for p in prices]
+
+
+def hypothetical_scenario(prices: List[float], shocks: List[float]) -> List[float]:
+    """Apply provided shocks to prices element-wise."""
+    if len(prices) != len(shocks):
+        raise ValueError("prices and shocks must be same length")
+    return [p * (1 + s) for p, s in zip(prices, shocks)]

--- a/risk-engine/tests/test_stress.py
+++ b/risk-engine/tests/test_stress.py
@@ -1,0 +1,34 @@
+# nosec
+"""Tests for stress scenarios v0.1.0 (2025-08-19)"""
+import importlib.util
+import sys
+from pathlib import Path
+
+__version__ = "0.1.0"
+
+ENGINE_DIR = Path(__file__).resolve().parents[1]
+
+
+def load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+stress = load("risk_engine.stress_tests", ENGINE_DIR / "stress_tests.py")
+
+
+def test_historical_scenario():
+    prices = [100.0, 95.0, 90.0]
+    result = stress.historical_scenario(prices)
+    assert len(result) == len(prices)  # nosec
+    assert result[-1] <= prices[-1]  # nosec
+
+
+def test_hypothetical_scenario():
+    prices = [100.0, 100.0]
+    shocks = [-0.1, -0.2]
+    result = stress.hypothetical_scenario(prices, shocks)
+    assert result == [90.0, 80.0]  # nosec

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.26
+# User Manual v0.6.27
 
 Date: 2025-08-19
 
@@ -37,6 +37,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - The feasibility-calculator service exposes `/feasibility` to estimate CAGR, daily returns and probability of hitting a target based on capital, goal, deadline and risk profile.
 - It now binds to `127.0.0.1` by default for improved security.
 - The backtester CLI loads prices from the database, simulates equal-weight portfolios, computes KPIs (CAGR, Sharpe, max drawdown), embeds equity charts in HTML reports and records metrics in the `backtests` table.
+- Risk engine additionally offers `/risk/stress` for historical and hypothetical scenario analysis with stored results.
 
 ### Strategy Engine
 - `strategy-engine` now provides `simulation.py` for Monte Carlo path generation and probability-of-hitting analysis.

--- a/user_manual_2025-08-19.md
+++ b/user_manual_2025-08-19.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.17
+# User Manual v0.6.18
 
 Date: 2025-08-19
 
@@ -86,6 +86,7 @@ Each service now includes a `requirements.txt` file to facilitate Docker builds 
 - REST endpoint `/adjust` consumed by `strategy-engine` via `risk_client`.
 - Logs stored in `logs/risk-engine.log` and metrics default to port `9002`.
 - Configuration values read from `config` package.
+- Endpoint `/risk/stress` returns historical and hypothetical stress scenarios and persists results.
 
 ## Execution Engine
 - Broker-agnostic `OrderHandler` with pluggable adapters (`IBKR`, `Binance`).


### PR DESCRIPTION
## Summary
- add historical & hypothetical stress utilities
- expose `/risk/stress` endpoint storing results and version header
- add `risk_stress_results` migration and schema check
- document usage and update requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4d05208b0832ca30009ce870ffc1f