### PR TITLE
feat: add notification service with event consumer

### DIFF
--- a/admin/db_check.php
+++ b/admin/db_check.php
@@ -1,6 +1,6 @@
 <?php
-// db_check.php v0.1.5 (2025-08-19)
-$expectedVersion = 'v0.1.2';
+// db_check.php v0.1.6 (2025-08-19)
+$expectedVersion = 'v0.1.3';
 $dsn = sprintf('pgsql:host=%s;port=%s;dbname=%s',
     getenv('DB_HOST') ?: 'localhost',
     getenv('DB_PORT') ?: '5432',
@@ -9,7 +9,7 @@ $user = getenv('DB_USER') ?: 'postgres';
 $pass = getenv('DB_PASS') ?: '';
 $requiredTables = [
     'users','goals','accounts','portfolios','positions','orders',
-    'executions','prices','signals','actions','risk_limits','metrics_daily','backtests','risk_stress_results'
+    'executions','prices','signals','actions','risk_limits','metrics_daily','backtests','risk_stress_results','notifications'
 ];
 $priceColumns = ['symbol','venue','ts','o','h','l','c','v'];
 try {
@@ -57,21 +57,30 @@ foreach ($metricsColumns as $col) {
 $backtestColumns = ['id','cfg_json','start','end','kpis_json','report_path'];
 $stmt = $pdo->query("SELECT column_name FROM information_schema.columns WHERE table_name='backtests'");
 $cols = $stmt->fetchAll(PDO::FETCH_COLUMN);
-foreach ($backtestColumns as $col) {
-    if (!in_array($col, $cols)) {
-        echo "Missing column in backtests: $col\n";
-        exit(1);
-    }
-}
-$stressColumns = ['id','scenario','metric','created_at'];
-$stmt = $pdo->query("SELECT column_name FROM information_schema.columns WHERE table_name='risk_stress_results'");
-$cols = $stmt->fetchAll(PDO::FETCH_COLUMN);
-foreach ($stressColumns as $col) {
-    if (!in_array($col, $cols)) {
-        echo "Missing column in risk_stress_results: $col\n";
-        exit(1);
-    }
-}
+  foreach ($backtestColumns as $col) {
+      if (!in_array($col, $cols)) {
+          echo "Missing column in backtests: $col\n";
+          exit(1);
+      }
+  }
+  $stressColumns = ['id','scenario','metric','created_at'];
+  $stmt = $pdo->query("SELECT column_name FROM information_schema.columns WHERE table_name='risk_stress_results'");
+  $cols = $stmt->fetchAll(PDO::FETCH_COLUMN);
+  foreach ($stressColumns as $col) {
+      if (!in_array($col, $cols)) {
+          echo "Missing column in risk_stress_results: $col\n";
+          exit(1);
+      }
+  }
+  $notificationColumns = ['id','user_id','channel','payload','created_at'];
+  $stmt = $pdo->query("SELECT column_name FROM information_schema.columns WHERE table_name='notifications'");
+  $cols = $stmt->fetchAll(PDO::FETCH_COLUMN);
+  foreach ($notificationColumns as $col) {
+      if (!in_array($col, $cols)) {
+          echo "Missing column in notifications: $col\n";
+          exit(1);
+      }
+  }
 $schemaVersion = getenv('DB_SCHEMA_VERSION') ?: 'unknown';
 if ($schemaVersion !== $expectedVersion) {
     echo "Schema version mismatch: expected $expectedVersion, got $schemaVersion\n";

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.28
+# Changelog v0.6.29
 
 ## 2025-02-14
 - Introduced user manual revision with installation, usage, architecture and troubleshooting sections.
@@ -88,6 +88,8 @@
 
 - Scaffolded `notification-service` with `/notify/email` and `/notify/webhook` endpoints, RabbitMQ consumer,
   log directory, installer scripts and `notifications` table migration with schema checks.
+
+- Made notification-service bind host configurable via environment variables to satisfy Bandit.
 
 ## 2025-08-18
 - Added initial development tasks outline.

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.27
+# Changelog v0.6.28
 
 ## 2025-02-14
 - Introduced user manual revision with installation, usage, architecture and troubleshooting sections.
@@ -85,6 +85,9 @@
 - Updated development tasks with new deliverables from the README and bumped README to v0.1.5 with current date linkage.
 - Replaced insecure asserts in execution-engine tests and bound feasibility-calculator to localhost to satisfy Bandit.
 - Added historical and hypothetical stress test endpoint `/risk/stress` with persistence, migrations and documentation.
+
+- Scaffolded `notification-service` with `/notify/email` and `/notify/webhook` endpoints, RabbitMQ consumer,
+  log directory, installer scripts and `notifications` table migration with schema checks.
 
 ## 2025-08-18
 - Added initial development tasks outline.

--- a/changelog_2025-08-19.md
+++ b/changelog_2025-08-19.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.23
+# Changelog v0.6.24
 
 ## 2025-08-19
 - Added shared monitoring utilities providing JSON logging, Prometheus metrics and OpenTelemetry traces.
@@ -64,7 +64,8 @@
 - Silenced npm http-proxy warning in UI tests via `.npmrc` loglevel setting.
 
 - Added historical and hypothetical stress test endpoint `/risk/stress` with persistence, migrations and documentation.
-
+- Scaffolded `notification-service` with `/notify/email` and `/notify/webhook` endpoints, RabbitMQ consumer,
+  log directory, installer scripts and `notifications` table migration with schema checks.
 
 ## 2025-08-18
 - Added initial development tasks outline.

--- a/changelog_2025-08-19.md
+++ b/changelog_2025-08-19.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.24
+# Changelog v0.6.25
 
 ## 2025-08-19
 - Added shared monitoring utilities providing JSON logging, Prometheus metrics and OpenTelemetry traces.
@@ -66,6 +66,8 @@
 - Added historical and hypothetical stress test endpoint `/risk/stress` with persistence, migrations and documentation.
 - Scaffolded `notification-service` with `/notify/email` and `/notify/webhook` endpoints, RabbitMQ consumer,
   log directory, installer scripts and `notifications` table migration with schema checks.
+
+- Made notification-service bind host configurable via environment variables to satisfy Bandit.
 
 ## 2025-08-18
 - Added initial development tasks outline.

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,4 +1,4 @@
-"""Configuration loader v0.1.5 (2025-08-19)"""
+"""Configuration loader v0.1.6 (2025-08-19)"""
 from dataclasses import dataclass
 from dotenv import load_dotenv
 import os
@@ -14,6 +14,7 @@ class Settings:
     execution_engine_metrics_port: int = int(os.getenv("EXECUTION_ENGINE_METRICS_PORT", "9003"))
     data_ingestion_metrics_port: int = int(os.getenv("DATA_INGESTION_METRICS_PORT", "9004"))
     backtester_metrics_port: int = int(os.getenv("BACKTESTER_METRICS_PORT", "9005"))
+    notification_service_metrics_port: int = int(os.getenv("NOTIFICATION_SERVICE_METRICS_PORT", "9006"))
     db_host: str = os.getenv("DB_HOST", "localhost")
     db_port: int = int(os.getenv("DB_PORT", "5432"))
     db_name: str = os.getenv("DB_NAME", "cashmachiine")

--- a/db/migrations/016_create_notifications.sql
+++ b/db/migrations/016_create_notifications.sql
@@ -1,0 +1,8 @@
+-- 016_create_notifications.sql v0.1.0 (2025-08-19)
+CREATE TABLE IF NOT EXISTS notifications (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL,
+    channel TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# docker-compose.yml v0.1.1 (2025-08-20)
+# docker-compose.yml v0.1.2 (2025-08-19)
 version: '3.8'
 services:
   db:
@@ -74,20 +74,30 @@ services:
       - db
       - cache
       - rabbitmq
-  feasibility-calculator:
-    build:
-      context: .
-      dockerfile: feasibility-calculator/Dockerfile
-    depends_on:
-      - db
-      - cache
-      - rabbitmq
-    ports:
-      - "8100:8000"
-  ui:
-    build:
-      context: ui
-    ports:
-      - "3000:3000"
+    feasibility-calculator:
+      build:
+        context: .
+        dockerfile: feasibility-calculator/Dockerfile
+      depends_on:
+        - db
+        - cache
+        - rabbitmq
+      ports:
+        - "8100:8000"
+    notification-service:
+      build:
+        context: .
+        dockerfile: notification-service/Dockerfile
+      depends_on:
+        - db
+        - cache
+        - rabbitmq
+      ports:
+        - "8200:8000"
+    ui:
+      build:
+        context: ui
+      ports:
+        - "3000:3000"
     depends_on:
       - api-gateway

--- a/notification-service/Dockerfile
+++ b/notification-service/Dockerfile
@@ -1,0 +1,7 @@
+# Dockerfile v0.1.0 (2025-08-19)
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir --disable-pip-version-check --root-user-action=ignore -r requirements.txt
+COPY . .
+CMD ["uvicorn", "notification-service.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/notification-service/__init__.py
+++ b/notification-service/__init__.py
@@ -1,0 +1,2 @@
+"""notification-service v0.3.0 (2025-08-19)"""
+__version__ = "0.3.0"

--- a/notification-service/__init__.py
+++ b/notification-service/__init__.py
@@ -1,2 +1,2 @@
-"""notification-service v0.3.0 (2025-08-19)"""
-__version__ = "0.3.0"
+"""notification-service v0.3.1 (2025-08-19)"""
+__version__ = "0.3.1"

--- a/notification-service/api.py
+++ b/notification-service/api.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-"""notification-service FastAPI app v0.3.0 (2025-08-19)"""
+"""notification-service FastAPI app v0.3.1 (2025-08-19)"""
 from __future__ import annotations
 
+import os
 import threading
 from typing import Any
 
@@ -14,7 +15,7 @@ from common.monitoring import setup_logging, setup_metrics, setup_tracer
 from config import settings
 from messaging import EventConsumer
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 logger = setup_logging(
     "notification-service",
@@ -101,4 +102,6 @@ def startup() -> None:
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run("notification-service.api:app", host="0.0.0.0", port=8000)
+    host = os.getenv("NOTIFICATION_HOST", "127.0.0.1")
+    port = int(os.getenv("NOTIFICATION_PORT", "8000"))
+    uvicorn.run("notification-service.api:app", host=host, port=port)

--- a/notification-service/api.py
+++ b/notification-service/api.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""notification-service FastAPI app v0.3.0 (2025-08-19)"""
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import psycopg2
+from psycopg2.extras import Json
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from common.monitoring import setup_logging, setup_metrics, setup_tracer
+from config import settings
+from messaging import EventConsumer
+
+__version__ = "0.3.0"
+
+logger = setup_logging(
+    "notification-service",
+    log_path="logs/notification-service/notification.log",
+    remote_url=settings.remote_log_url,
+)
+REQUEST_COUNT = setup_metrics("notification-service", port=settings.notification_service_metrics_port)
+tracer = setup_tracer("notification-service")
+
+app = FastAPI(title="notification-service", version=__version__)
+
+
+class EmailNotification(BaseModel):
+    user_id: int
+    to: str
+    subject: str
+    body: str
+
+
+class WebhookNotification(BaseModel):
+    user_id: int
+    url: str
+    payload: dict[str, Any]
+
+
+def save_notification(channel: str, payload: dict[str, Any]) -> None:
+    conn = psycopg2.connect(
+        host=settings.db_host,
+        port=settings.db_port,
+        dbname=settings.db_name,
+        user=settings.db_user,
+        password=settings.db_pass,
+    )
+    with conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """INSERT INTO notifications (user_id, channel, payload) VALUES (%s, %s, %s)""",
+                (payload.get("user_id", 0), channel, Json(payload)),
+            )
+    conn.close()
+
+
+@app.post("/notify/email")
+def notify_email(note: EmailNotification) -> dict[str, str]:
+    with tracer.start_as_current_span("notify-email"):
+        save_notification("email", note.dict())
+        logger.info("Queued email notification", extra={"to": note.to})
+        REQUEST_COUNT.inc()
+    return {"status": "queued"}
+
+
+@app.post("/notify/webhook")
+def notify_webhook(note: WebhookNotification) -> dict[str, str]:
+    with tracer.start_as_current_span("notify-webhook"):
+        save_notification("webhook", note.dict())
+        logger.info("Queued webhook notification", extra={"url": note.url})
+        REQUEST_COUNT.inc()
+    return {"status": "queued"}
+
+
+def handle_event(message: dict[str, Any]) -> None:
+    channel = message.get("channel", "email")
+    payload = message.get("payload", {})
+    with tracer.start_as_current_span(f"event-{channel}"):
+        save_notification(channel, payload)
+        logger.info("Processed event notification", extra={"channel": channel})
+        REQUEST_COUNT.inc()
+
+
+def start_consumer() -> None:
+    consumer = EventConsumer(settings.rabbitmq_url, queue="notifications")
+    try:
+        consumer.start(handle_event)
+    finally:
+        consumer.close()
+
+
+@app.on_event("startup")
+def startup() -> None:
+    thread = threading.Thread(target=start_consumer, daemon=True)
+    thread.start()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("notification-service.api:app", host="0.0.0.0", port=8000)

--- a/notification-service/install.sh
+++ b/notification-service/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# notification-service installer v0.3.0
+# notification-service installer v0.3.1
 echo "Installing notification-service service..."
 pip install --no-cache-dir --disable-pip-version-check --root-user-action=ignore -r requirements.txt >/dev/null
 mkdir -p "$(dirname "$0")/../logs/notification-service"

--- a/notification-service/install.sh
+++ b/notification-service/install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# notification-service installer v0.3.0
+echo "Installing notification-service service..."
+pip install --no-cache-dir --disable-pip-version-check --root-user-action=ignore -r requirements.txt >/dev/null
+mkdir -p "$(dirname "$0")/../logs/notification-service"

--- a/notification-service/remove.sh
+++ b/notification-service/remove.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# notification-service removal v0.3.0
+# notification-service removal v0.3.1
 echo "Removing notification-service service..."
 pip uninstall -y -r requirements.txt >/dev/null 2>&1

--- a/notification-service/remove.sh
+++ b/notification-service/remove.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# notification-service removal v0.3.0
+echo "Removing notification-service service..."
+pip uninstall -y -r requirements.txt >/dev/null 2>&1

--- a/notification-service/requirements.txt
+++ b/notification-service/requirements.txt
@@ -1,0 +1,15 @@
+# requirements.txt v0.1.0 (2025-08-19)
+requests>=2.31.0
+fastapi>=0.110.0
+uvicorn>=0.29.0
+python-jose[cryptography]>=3.3.0
+apscheduler>=3.10.4
+yfinance>=0.2.40
+ccxt>=4.0.0
+psycopg2-binary>=2.9.9
+numpy>=1.26.0
+prometheus-client>=0.20.0
+opentelemetry-sdk>=1.24.0
+python-dotenv>=1.0.1
+redis>=5.0.0
+pika>=1.3.2

--- a/tools/log_create.sh
+++ b/tools/log_create.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# log directory creator v0.6.9 (2025-08-19)
+# log directory creator v0.6.10 (2025-08-19)
 set -e
 mkdir -p logs
 mkdir -p logs/containers
@@ -8,6 +8,7 @@ mkdir -p backtester/reports
 mkdir -p ui/.next
 mkdir -p perf
 mkdir -p execution-engine/logs
+mkdir -p logs/notification-service
 touch logs/orchestrator.log
 touch logs/data-ingestion.log
 touch logs/strategy-engine.log
@@ -16,4 +17,5 @@ touch logs/execution-engine.log
 touch logs/messaging.log
 touch logs/feasibility-calculator.log
 touch logs/backtester.log
+touch logs/notification-service/notification.log
 touch execution-engine/logs/orders.log

--- a/tools/log_create_win.cmd
+++ b/tools/log_create_win.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM log directory creator v0.6.9 (2025-08-19)
+REM log directory creator v0.6.10 (2025-08-19)
 mkdir logs 2>nul
 mkdir logs\containers 2>nul
 mkdir logs\analytics 2>nul
@@ -7,6 +7,7 @@ mkdir backtester\reports 2>nul
 mkdir ui\.next 2>nul
 mkdir perf 2>nul
 mkdir execution-engine\logs 2>nul
+mkdir logs\notification-service 2>nul
 type nul > logs\orchestrator.log
 type nul > logs\data-ingestion.log
 type nul > logs\strategy-engine.log
@@ -15,4 +16,5 @@ type nul > logs\execution-engine.log
 type nul > logs\messaging.log
 type nul > logs\feasibility-calculator.log
 type nul > logs\backtester.log
+type nul > logs\notification-service\notification.log
 type nul > execution-engine\logs\orders.log

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.27
+# User Manual v0.6.28
 
 Date: 2025-08-19
 
@@ -28,6 +28,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
  - The orchestrator sequentially dispatches `data_fetch`, `strategy_compute`, `risk_adjust` and `order_dispatch` events.
  - `data_fetch` covers equities, bonds and commodities via Alpha Vantage fetchers.
 - Data ingestion, strategy-engine, risk-engine and execution-engine consume these events from RabbitMQ.
+- The notification-service offers `/notify/email` and `/notify/webhook`, consumes `notifications` events and logs to `logs/notification-service/`.
 - Execution-engine adapters pull API keys from configuration (`BINANCE_API_KEY`, `BINANCE_API_SECRET`, `IBKR_API_KEY`). Orders
   are persisted to `orders` and `executions` tables, cached in Redis and logged to `execution-engine/logs/orders.log`.
 - Pass `--install` or `--remove` to service scripts for setup and teardown.

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.28
+# User Manual v0.6.29
 
 Date: 2025-08-19
 
@@ -29,6 +29,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
  - `data_fetch` covers equities, bonds and commodities via Alpha Vantage fetchers.
 - Data ingestion, strategy-engine, risk-engine and execution-engine consume these events from RabbitMQ.
 - The notification-service offers `/notify/email` and `/notify/webhook`, consumes `notifications` events and logs to `logs/notification-service/`.
+- Configure its binding via `NOTIFICATION_HOST` (default `127.0.0.1`) and `NOTIFICATION_PORT`.
 - Execution-engine adapters pull API keys from configuration (`BINANCE_API_KEY`, `BINANCE_API_SECRET`, `IBKR_API_KEY`). Orders
   are persisted to `orders` and `executions` tables, cached in Redis and logged to `execution-engine/logs/orders.log`.
 - Pass `--install` or `--remove` to service scripts for setup and teardown.

--- a/user_manual_2025-08-19.md
+++ b/user_manual_2025-08-19.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.19
+# User Manual v0.6.20
 
 Date: 2025-08-19
 
@@ -98,7 +98,8 @@ Each service now includes a `requirements.txt` file to facilitate Docker builds 
 - FastAPI service exposing `/notify/email` and `/notify/webhook`.
 - Consumes RabbitMQ `notifications` queue.
 - Logs stored in `logs/notification-service/notification.log`.
-- Install with `notification-service/install.sh` and remove with `notification-service/remove.sh` (v0.3.0).
+- Install with `notification-service/install.sh` and remove with `notification-service/remove.sh` (v0.3.1).
+- Configure bind address via `NOTIFICATION_HOST` (default `127.0.0.1`) and `NOTIFICATION_PORT`.
 
 ## Backtester
 - Generate HTML performance reports from strategy configs.

--- a/user_manual_2025-08-19.md
+++ b/user_manual_2025-08-19.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.18
+# User Manual v0.6.19
 
 Date: 2025-08-19
 
@@ -14,6 +14,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - orchestrator
 - data-ingestion
 - messaging
+- notification-service
 - strategy-engine
 - risk-engine
 - execution-engine
@@ -92,6 +93,12 @@ Each service now includes a `requirements.txt` file to facilitate Docker builds 
 - Broker-agnostic `OrderHandler` with pluggable adapters (`IBKR`, `Binance`).
 - Structured JSON order logs written to `logs/execution-engine.log`.
 - Install with `execution-engine/install.sh` and remove with `execution-engine/remove.sh` (v0.4.3).
+
+## Notification Service
+- FastAPI service exposing `/notify/email` and `/notify/webhook`.
+- Consumes RabbitMQ `notifications` queue.
+- Logs stored in `logs/notification-service/notification.log`.
+- Install with `notification-service/install.sh` and remove with `notification-service/remove.sh` (v0.3.0).
 
 ## Backtester
 - Generate HTML performance reports from strategy configs.


### PR DESCRIPTION
## Summary
- add FastAPI notification-service with email and webhook endpoints
- consume RabbitMQ notifications queue and persist messages
- document setup and create migration, logs and schema checks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4e04c17ac832c9733c8e2450f8631