### PR TITLE
feat(strategy-engine): add ML price forecasting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# .gitignore v0.2.12 (2025-08-19)
+# .gitignore v0.2.14 (2025-08-19)
 # Python artifacts
 __pycache__/
 *.py[cod]
@@ -36,3 +36,5 @@ logs/
 backtester/reports/
 perf/
 execution-engine/logs/
+strategy-engine/models/*
+!strategy-engine/models/.gitkeep

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.29
+# Changelog v0.6.30
 
 ## 2025-02-14
 - Introduced user manual revision with installation, usage, architecture and troubleshooting sections.
@@ -136,6 +136,7 @@
 - Implemented database-driven price loading and portfolio simulation in backtester CLI with KPI charts.
 - Stored backtest metrics in the `backtests` table and expanded schema checks.
 - Added pandas and matplotlib dependencies with version bumps and updated tests and user manual.
+- Introduced RandomForest-based price forecasting with model storage under `strategy-engine/models/` and scikit-learn dependency.
 
 ## 2025-08-20
 - Added Next.js internationalization with French default and English fallback locales.

--- a/changelog_2025-08-19.md
+++ b/changelog_2025-08-19.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.25
+# Changelog v0.6.26
 
 ## 2025-08-19
 - Added shared monitoring utilities providing JSON logging, Prometheus metrics and OpenTelemetry traces.
@@ -68,6 +68,7 @@
   log directory, installer scripts and `notifications` table migration with schema checks.
 
 - Made notification-service bind host configurable via environment variables to satisfy Bandit.
+- Introduced RandomForest-based price forecasting with model storage under `strategy-engine/models/` and scikit-learn dependency.
 
 ## 2025-08-18
 - Added initial development tasks outline.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# requirements.txt v0.3.4 (2025-08-19)
+# requirements.txt v0.3.5 (2025-08-19)
 
 # Runtime dependencies
 requests>=2.31.0
@@ -18,6 +18,7 @@ opentelemetry-sdk>=1.24.0
 python-dotenv>=1.0.1
 redis>=5.0.0
 pika>=1.3.2
+scikit-learn>=1.4.2
 
 # Development dependencies
 pytest>=8.2.0

--- a/strategy-engine/__init__.py
+++ b/strategy-engine/__init__.py
@@ -1,5 +1,5 @@
-"""strategy-engine service v0.4.5 (2025-08-20)"""
-__version__ = "0.4.5"
+"""strategy-engine service v0.3.0 (2025-08-19)"""
+__version__ = "0.3.0"
 
 from strategy_engine.interface import Strategy
 from strategy_engine.risk_client import adjust_risk

--- a/strategy-engine/install.sh
+++ b/strategy-engine/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# strategy-engine installer v0.4.4
+# strategy-engine installer v0.3.0
 
 echo "Installing strategy-engine service..."
 pip install --no-cache-dir --disable-pip-version-check --root-user-action=ignore -r requirements.txt >/dev/null

--- a/strategy-engine/main.py
+++ b/strategy-engine/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""strategy-engine consumer v0.4.3 (2025-08-19)"""
+"""strategy-engine consumer v0.3.0 (2025-08-19)"""
 import argparse
 import os
 import subprocess  # nosec B404
@@ -29,7 +29,7 @@ def handle_event(message: dict) -> None:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="strategy-engine consumer v0.4.3")
+    parser = argparse.ArgumentParser(description="strategy-engine consumer v0.3.0")
     parser.add_argument("--install", action="store_true", help="Install strategy-engine service")
     parser.add_argument("--remove", action="store_true", help="Remove strategy-engine service")
     parser.add_argument("--log-path", default=os.path.join("logs", "strategy-engine.log"), help="Path to log file")

--- a/strategy-engine/ml_forecast.py
+++ b/strategy-engine/ml_forecast.py
@@ -1,0 +1,38 @@
+"""Machine learning forecast utilities v0.1.0 (2025-08-19)"""
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+from sklearn.ensemble import RandomForestRegressor
+import joblib
+
+__version__ = "0.1.0"
+
+MODEL_DIR = Path(__file__).resolve().parent / "models"
+MODEL_DIR.mkdir(exist_ok=True)
+
+
+def forecast_prices(symbol: str, history: Sequence[float]) -> float:
+    """Forecast the next price for *symbol* based on *history* of prices.
+
+    A simple RandomForestRegressor is trained per symbol and cached under
+    ``strategy-engine/models``. If insufficient history is provided, the latest
+    price is returned.
+    """
+    prices = list(history)
+    if len(prices) < 2:
+        return float(prices[-1]) if prices else 0.0
+
+    model_path = MODEL_DIR / f"{symbol}_rf.joblib"
+    X = np.arange(len(prices)).reshape(-1, 1)
+    y = np.array(prices)
+
+    if model_path.exists():
+        model = joblib.load(model_path)
+    else:
+        model = RandomForestRegressor(n_estimators=100, random_state=42)
+        model.fit(X, y)
+        joblib.dump(model, model_path)
+
+    next_index = np.array([[len(prices)]])
+    return float(model.predict(next_index)[0])

--- a/strategy-engine/remove.sh
+++ b/strategy-engine/remove.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# strategy-engine removal v0.4.4
+# strategy-engine removal v0.3.0
 
 echo "Removing strategy-engine service..."
 pip uninstall -y -r requirements.txt >/dev/null 2>&1

--- a/strategy-engine/requirements.txt
+++ b/strategy-engine/requirements.txt
@@ -1,4 +1,4 @@
-# requirements.txt v0.1.0 (2025-08-19)
+# requirements.txt v0.1.1 (2025-08-19)
 requests>=2.31.0
 fastapi>=0.110.0
 uvicorn>=0.29.0
@@ -13,3 +13,4 @@ opentelemetry-sdk>=1.24.0
 python-dotenv>=1.0.1
 redis>=5.0.0
 pika>=1.3.2
+scikit-learn>=1.4.2

--- a/strategy-engine/strategies/satellite.py
+++ b/strategy-engine/strategies/satellite.py
@@ -1,9 +1,10 @@
-"""Satellite strategy example v0.1.2 (2025-08-20)"""
+"""Satellite strategy example v0.1.3 (2025-08-19)"""
 from strategy_engine.interface import Strategy
 from strategy_engine.risk_client import adjust_risk
+from strategy_engine.ml_forecast import forecast_prices
 from common.monitoring import setup_performance_metrics
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 SIGNAL_LATENCY = setup_performance_metrics("strategy-engine-satellite")
 
@@ -16,10 +17,12 @@ class SatelliteStrategy(Strategy):
 
     def signals(self, market_data):
         with SIGNAL_LATENCY.time():
-            price = market_data.get("BTC", {}).get("close", 0)
-            prev = market_data.get("BTC", {}).get("prev_close", price)
-            ret = (price - prev) / prev if prev else 0.0
-            return {"BTC": ret}
+            symbol = "BTC"
+            price = market_data.get(symbol, {}).get("close", 0)
+            history = market_data.get(symbol, {}).get("history", [])
+            forecast = forecast_prices(symbol, history + [price])
+            ret = (forecast - price) / price if price else 0.0
+            return {symbol: ret}
 
     def target_weights(self, signals):
         raw = 0.1 if signals.get("BTC", 0) > 0 else 0.0

--- a/strategy-engine/tests/test_interface.py
+++ b/strategy-engine/tests/test_interface.py
@@ -1,11 +1,11 @@
 # nosec
-"""Unit test stubs for strategy interface v0.1.2 (2025-08-20)"""
+"""Unit test stubs for strategy interface v0.1.3 (2025-08-19)"""
 import importlib.util
 import sys
 from pathlib import Path
 import types
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 ENGINE_DIR = Path(__file__).resolve().parents[1]
 
@@ -30,8 +30,9 @@ def test_core_strategy_interface(monkeypatch):
     monkeypatch.setattr(
         core, "adjust_risk", lambda **_: {"weights": [1.0], "explanation": "stub"}
     )
+    monkeypatch.setattr(core, "forecast_prices", lambda *_, **__: 101.0)
     strategy = core.CoreStrategy()
-    sigs = strategy.signals({"SPY": {"close": 101, "prev_close": 100}})
+    sigs = strategy.signals({"SPY": {"close": 101, "history": [100, 101]}})
     weights = strategy.target_weights(sigs)
     assert isinstance(sigs, dict)  # nosec
     assert isinstance(weights, dict)  # nosec
@@ -42,8 +43,9 @@ def test_satellite_strategy_interface(monkeypatch):
     monkeypatch.setattr(
         satellite, "adjust_risk", lambda **_: {"weights": [0.1], "explanation": "stub"}
     )
+    monkeypatch.setattr(satellite, "forecast_prices", lambda *_, **__: 101.0)
     strategy = satellite.SatelliteStrategy()
-    sigs = strategy.signals({"BTC": {"close": 101, "prev_close": 100}})
+    sigs = strategy.signals({"BTC": {"close": 101, "history": [100, 101]}})
     weights = strategy.target_weights(sigs)
     assert isinstance(sigs, dict)  # nosec
     assert isinstance(weights, dict)  # nosec

--- a/strategy-engine/tests/test_ml_forecast.py
+++ b/strategy-engine/tests/test_ml_forecast.py
@@ -1,0 +1,29 @@
+# nosec
+"""Tests for ML forecast utilities v0.1.0 (2025-08-19)"""
+import importlib.util
+import sys
+from pathlib import Path
+import types
+
+__version__ = "0.1.0"
+
+ENGINE_DIR = Path(__file__).resolve().parents[1]
+
+
+def load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+pkg = types.ModuleType("strategy_engine")
+pkg.__path__ = [str(ENGINE_DIR)]
+sys.modules["strategy_engine"] = pkg
+ml = load("strategy_engine.ml_forecast", ENGINE_DIR / "ml_forecast.py")
+
+
+def test_forecast_prices_returns_float(tmp_path):
+    pred = ml.forecast_prices("TEST", [1, 2, 3])
+    assert isinstance(pred, float)  # nosec

--- a/tools/log_create.sh
+++ b/tools/log_create.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# log directory creator v0.6.10 (2025-08-19)
+# log directory creator v0.6.11 (2025-08-19)
 set -e
 mkdir -p logs
 mkdir -p logs/containers
@@ -9,6 +9,7 @@ mkdir -p ui/.next
 mkdir -p perf
 mkdir -p execution-engine/logs
 mkdir -p logs/notification-service
+mkdir -p strategy-engine/models
 touch logs/orchestrator.log
 touch logs/data-ingestion.log
 touch logs/strategy-engine.log

--- a/tools/log_create_win.cmd
+++ b/tools/log_create_win.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM log directory creator v0.6.10 (2025-08-19)
+REM log directory creator v0.6.11 (2025-08-19)
 mkdir logs 2>nul
 mkdir logs\containers 2>nul
 mkdir logs\analytics 2>nul
@@ -8,6 +8,7 @@ mkdir ui\.next 2>nul
 mkdir perf 2>nul
 mkdir execution-engine\logs 2>nul
 mkdir logs\notification-service 2>nul
+mkdir strategy-engine\models 2>nul
 type nul > logs\orchestrator.log
 type nul > logs\data-ingestion.log
 type nul > logs\strategy-engine.log

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.29
+# User Manual v0.6.30
 
 Date: 2025-08-19
 
@@ -44,6 +44,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 ### Strategy Engine
 - `strategy-engine` now provides `simulation.py` for Monte Carlo path generation and probability-of-hitting analysis.
 - Core and satellite strategies consume market data, call the risk engine for adjustments, and expose `explain()` for weight justification.
+- `ml_forecast.py` supplies `forecast_prices()` using RandomForest models stored in `strategy-engine/models/`.
 
 ## Performance
 - Run benchmarks with `pytest --benchmark-json=perf/<service>/results.json`.

--- a/user_manual_2025-08-19.md
+++ b/user_manual_2025-08-19.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.20
+# User Manual v0.6.21
 
 Date: 2025-08-19
 
@@ -81,6 +81,8 @@ Each service now includes a `requirements.txt` file to facilitate Docker builds 
 ## Strategy Engine
 - Base `Strategy` interface exposing `signals()` and `target_weights()`.
 - Example implementations: `CoreStrategy` and `SatelliteStrategy`.
+- `forecast_prices()` uses RandomForest models trained on historical data.
+- Models are stored under `strategy-engine/models/` (created by log scripts).
 
 ## Risk Engine
 - Provides volatility targeting, Value-at-Risk/Expected Shortfall checks, and Kelly fraction caps.


### PR DESCRIPTION
## Summary
- add RandomForest-based price forecasting with persisted models
- expose `forecast_prices()` for strategies and document usage
- track model artifacts and include scikit-learn dependency

## Testing
- `pip install scikit-learn>=1.4.2`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4e8f535a0832c97ed91813c3870b0