### PR TITLE
feat: add data warehouse ETL and migrations

### DIFF
--- a/admin/db_check.php
+++ b/admin/db_check.php
@@ -1,6 +1,6 @@
 <?php
-// db_check.php v0.1.8 (2025-08-19)
-$expectedVersion = 'v0.1.5';
+// db_check.php v0.1.9 (2025-08-19)
+$expectedVersion = 'v0.1.6';
 $dsn = sprintf('pgsql:host=%s;port=%s;dbname=%s',
     getenv('DB_HOST') ?: 'localhost',
     getenv('DB_PORT') ?: '5432',
@@ -12,6 +12,7 @@ $requiredTables = [
     'executions','prices','signals','actions','risk_limits','metrics_daily',
     'backtests','risk_stress_results','notifications','strategies','strategy_reviews'
 ];
+$warehouseTables = ['dw_orders','dw_positions'];
 $priceColumns = ['symbol','venue','ts','o','h','l','c','v'];
 try {
     $pdo = new PDO($dsn, $user, $pass, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
@@ -23,6 +24,13 @@ foreach ($requiredTables as $tbl) {
     $stmt = $pdo->query("SELECT to_regclass('public.$tbl')");
     if (!$stmt->fetchColumn()) {
         echo "Missing table: $tbl\n";
+        exit(1);
+    }
+}
+foreach ($warehouseTables as $tbl) {
+    $stmt = $pdo->query("SELECT to_regclass('warehouse.$tbl')");
+    if (!$stmt->fetchColumn()) {
+        echo "Missing warehouse table: $tbl\n";
         exit(1);
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.36
+# Changelog v0.6.37
 
 ## 2025-01-14
 - Added Playwright end-to-end tests under `tests/e2e` for UI and API flows.
@@ -38,6 +38,10 @@
 - Added Dockerfiles for all services with version headers.
 - Introduced root docker-compose.yml wiring services, database, cache and message bus.
 - Updated setup/remove scripts to invoke `docker-compose up` and `docker-compose down`.
+- Added data-warehouse module with nightly ETL and warehouse schema migrations.
+- Logged ETL runs under `logs/data-warehouse/` and updated log creation scripts.
+- Created warehouse migrations and updated `admin/db_check.php` for new tables.
+- Updated root requirements with SQLAlchemy and refreshed documentation.
 - Extended log creation scripts to include container log directories.
 - Added Bandit and `npm audit` security scans to CI with automatic dependency alerts.
 - Added Bandit dependency and UI `audit` script.

--- a/data-warehouse/__init__.py
+++ b/data-warehouse/__init__.py
@@ -1,0 +1,1 @@
+# data-warehouse package v0.1.0 (2025-08-19)

--- a/data-warehouse/etl_nightly.py
+++ b/data-warehouse/etl_nightly.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Nightly ETL from operational DB to warehouse schema.
+
+etl_nightly.py v0.1.0 (2025-08-19)
+"""
+import logging
+import os
+from sqlalchemy import create_engine, text
+
+LOG_DIR = os.path.join('logs', 'data-warehouse')
+os.makedirs(LOG_DIR, exist_ok=True)
+LOG_PATH = os.path.join(LOG_DIR, 'etl.log')
+logging.basicConfig(filename=LOG_PATH, level=logging.INFO,
+                    format='%(asctime)s %(levelname)s %(message)s')
+
+
+def run():
+    """Run ETL transferring orders and positions into warehouse schema."""
+    src_dsn = os.getenv('OP_DB_DSN', 'postgresql://postgres@localhost:5432/cashmachiine')
+    engine = create_engine(src_dsn)
+    logging.info('Starting ETL run')
+    with engine.begin() as conn:
+        conn.execute(text(
+            "INSERT INTO warehouse.dw_orders "
+            "(id, user_id, symbol, qty, price, created_at) "
+            "SELECT id, user_id, symbol, qty, price, created_at FROM public.orders"
+        ))
+        conn.execute(text(
+            "INSERT INTO warehouse.dw_positions "
+            "(id, account_id, symbol, qty, updated_at) "
+            "SELECT id, account_id, symbol, qty, updated_at FROM public.positions"
+        ))
+    logging.info('ETL run complete')
+
+
+if __name__ == '__main__':
+    run()

--- a/data-warehouse/install.sh
+++ b/data-warehouse/install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# data-warehouse installer v0.1.0 (2025-08-19)
+echo "Installing data-warehouse service..."
+pip install --no-cache-dir --disable-pip-version-check --root-user-action=ignore -r requirements.txt >/dev/null
+mkdir -p logs/data-warehouse

--- a/data-warehouse/remove.sh
+++ b/data-warehouse/remove.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# data-warehouse removal v0.1.0 (2025-08-19)
+echo "Removing data-warehouse service..."
+pip uninstall -y -r requirements.txt >/dev/null 2>&1

--- a/data-warehouse/requirements.txt
+++ b/data-warehouse/requirements.txt
@@ -1,0 +1,3 @@
+# requirements.txt v0.1.0 (2025-08-19)
+sqlalchemy>=2.0.29
+psycopg2-binary>=2.9.9

--- a/db/migrations/warehouse/001_create_dw_orders.sql
+++ b/db/migrations/warehouse/001_create_dw_orders.sql
@@ -1,0 +1,10 @@
+-- 001_create_dw_orders.sql v0.1.0 (2025-08-19)
+CREATE SCHEMA IF NOT EXISTS warehouse;
+CREATE TABLE IF NOT EXISTS warehouse.dw_orders (
+    id BIGINT PRIMARY KEY,
+    user_id BIGINT,
+    symbol TEXT,
+    qty NUMERIC,
+    price NUMERIC,
+    created_at TIMESTAMP
+);

--- a/db/migrations/warehouse/002_create_dw_positions.sql
+++ b/db/migrations/warehouse/002_create_dw_positions.sql
@@ -1,0 +1,8 @@
+-- 002_create_dw_positions.sql v0.1.0 (2025-08-19)
+CREATE TABLE IF NOT EXISTS warehouse.dw_positions (
+    id BIGINT PRIMARY KEY,
+    account_id BIGINT,
+    symbol TEXT,
+    qty NUMERIC,
+    updated_at TIMESTAMP
+);

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# requirements.txt v0.3.6 (2025-01-14)
+# requirements.txt v0.3.7 (2025-08-19)
 
 # Runtime dependencies
 requests>=2.31.0
@@ -19,6 +19,7 @@ python-dotenv>=1.0.1
 redis>=5.0.0
 pika>=1.3.2
 scikit-learn>=1.4.2
+sqlalchemy>=2.0.29
 
 # Development dependencies
 pytest>=8.2.0

--- a/tools/log_create.sh
+++ b/tools/log_create.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# log directory creator v0.6.16 (2025-08-19)
+# log directory creator v0.6.17 (2025-08-19)
 set -e
 mkdir -p logs
 mkdir -p logs/containers
@@ -13,6 +13,7 @@ mkdir -p infra/terraform/logs
 mkdir -p logs/notification-service
 mkdir -p logs/strategy-marketplace
 mkdir -p logs/mobile
+mkdir -p logs/data-warehouse
 mkdir -p strategy-engine/models
 mkdir -p strategy-marketplace/assets
 mkdir -p backups
@@ -28,3 +29,4 @@ touch logs/notification-service/notification.log
 touch logs/strategy-marketplace/marketplace.log
 touch execution-engine/logs/orders.log
 touch logs/mobile/build.log
+touch logs/data-warehouse/etl.log

--- a/tools/log_create_win.cmd
+++ b/tools/log_create_win.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM log directory creator v0.6.16 (2025-08-19)
+REM log directory creator v0.6.17 (2025-08-19)
 mkdir logs 2>nul
 mkdir logs\containers 2>nul
 mkdir logs\analytics 2>nul
@@ -12,6 +12,7 @@ mkdir infra\terraform\logs 2>nul
 mkdir logs\notification-service 2>nul
 mkdir logs\strategy-marketplace 2>nul
 mkdir logs\mobile 2>nul
+mkdir logs\data-warehouse 2>nul
 mkdir strategy-engine\models 2>nul
 mkdir strategy-marketplace\assets 2>nul
 mkdir backups 2>nul
@@ -27,3 +28,4 @@ type nul > logs\notification-service\notification.log
 type nul > logs\strategy-marketplace\marketplace.log
 type nul > execution-engine\logs\orders.log
 type nul > logs\mobile\build.log
+type nul > logs\data-warehouse\etl.log

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.36
+# User Manual v0.6.37
 
 Date: 2025-08-19
 
@@ -37,6 +37,11 @@ This document will evolve into a comprehensive encyclopedia for the project.
 ## Mobile Application
 - React Native app initialized under `mobile/` with a simple entry point.
 - Use `mobile/build.sh` to generate mobile build logs in `logs/mobile/`.
+
+## Data Warehouse
+- Nightly ETL scripts load operational data into an analytical `warehouse` schema.
+- Logs reside in `logs/data-warehouse/etl.log`.
+- Install with `data-warehouse/install.sh` and remove with `data-warehouse/remove.sh` (v0.1.0).
 
 ## Usage
 - Authenticate and interact with the API Gateway at `/goals`, `/goals/{id}/status`, `/actions/today`, `/actions/{id}/check` and `/orders/preview`. Requests are scoped by the `tenant_id` embedded in JWT tokens.

--- a/user_manual_2025-08-19.md
+++ b/user_manual_2025-08-19.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.36
+# User Manual v0.6.37
 
 Date: 2025-08-19
 
@@ -13,6 +13,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - api-gateway
 - orchestrator
 - data-ingestion
+- data-warehouse
 - messaging
 - notification-service
 - strategy-marketplace
@@ -94,6 +95,11 @@ Each service now includes a `requirements.txt` file to facilitate Docker builds 
   - `from data_ingestion.fetchers.equities_yahoo import YahooEquityFetcher`
   - `YahooEquityFetcher().save(YahooEquityFetcher().fetch("AAPL"))`
 - Logs stored in `logs/data-ingestion.log`.
+
+## Data Warehouse
+- Nightly ETL transfers operational data into the `warehouse` schema.
+- Logs stored in `logs/data-warehouse/etl.log`.
+- Install with `data-warehouse/install.sh` and remove with `data-warehouse/remove.sh` (v0.1.0).
 
 ## Strategy Engine
 - Base `Strategy` interface exposing `signals()` and `target_weights()`.


### PR DESCRIPTION
## Summary
- scaffold `data-warehouse` package with nightly ETL
- add warehouse schema migrations and update db check
- log ETL runs and document data warehouse module

## Testing
- `python -m py_compile data-warehouse/etl_nightly.py`
- `php -l admin/db_check.php`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4fdf357d4832c909a389a836a38b9