### PR TITLE
docs: update tasks and manuals

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.37
+# Changelog v0.6.38
 
 ## 2025-01-14
 - Added Playwright end-to-end tests under `tests/e2e` for UI and API flows.
@@ -119,6 +119,7 @@
 - Enabled PWA support in Next.js UI with service worker, manifest and offline cache.
 - Added `logs/mobile/` path to log creation scripts for mobile build artifacts.
 - Documented mobile and PWA features in user manuals.
+- Reviewed development tasks, marking feasibility calculator, action UI export and backtester HTML reports as complete with cross-references in user manuals.
 
 ## 2025-08-18
 - Added initial development tasks outline.

--- a/development_tasks_2025-08-19.md
+++ b/development_tasks_2025-08-19.md
@@ -1,4 +1,4 @@
-# Development Tasks v0.1.2
+# Development Tasks v0.1.3
 
 Date: 2025-08-19
 
@@ -26,8 +26,10 @@ Date: 2025-08-19
 - [x] Maintain `changelog` for every update with version and date.
 
 ## MVP Deliverables
-- [ ] Implement `feasibility-calculator` service (API + UI) for goal feasibility calculations.
-- [ ] Extend `actions` UI with checklist and export of orders.
-- [ ] Generate HTML reports in `backtester` CLI.
+- [x] Implement `feasibility-calculator` service (API + UI) for goal feasibility calculations. See [Feasibility Calculator](user_manual_2025-08-19.md#feasibility-calculator).
+- [x] Extend `actions` UI with checklist and export of orders. See [UI](user_manual_2025-08-19.md#ui).
+- [x] Generate HTML reports in `backtester` CLI. See [Backtester](user_manual_2025-08-19.md#backtester).
+- [ ] Integrate feasibility calculator results into the UI overview. See [Feasibility Calculator](user_manual_2025-08-19.md#feasibility-calculator).
+- [ ] Implement automated tests for `feasibility-calculator` service. See [Feasibility Calculator](user_manual_2025-08-19.md#feasibility-calculator).
 
 Refer to [user_manual_2025-08-19.md](user_manual_2025-08-19.md) for installation and usage details.

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,11 +1,11 @@
-# User Manual v0.6.37
+# User Manual v0.6.38
 
 Date: 2025-08-19
 
 This document will evolve into a comprehensive encyclopedia for the project.
 
 ## Development Roadmap
-- Refer to [development_tasks.md](development_tasks.md) for the latest task status.
+- Refer to [development_tasks_2025-08-19.md](development_tasks_2025-08-19.md) for the latest task status.
 
 ## Installation
 - Copy `.env.example` to `.env` and adjust values as needed, including `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, `RATE_LIMIT_PER_MINUTE`, `ALPHA_VANTAGE_KEY`, `BINANCE_API_KEY`, `BINANCE_API_SECRET` and `IBKR_API_KEY`.
@@ -60,6 +60,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Pass `--install` or `--remove` to service scripts for setup and teardown.
 - The UI supports French and English; append `/en` to URLs to switch to English.
 - Mark tasks complete on the daily actions page; checkboxes send POST requests to `/actions/{id}/check` and show feedback messages.
+- The daily actions checklist also allows exporting orders for external processing.
 - Visualize aggregated metrics via the `/analytics` endpoint or the UI analytics page, which renders charts with Chart.js.
 - The feasibility-calculator service exposes `/feasibility` to estimate CAGR, daily returns and probability of hitting a target based on capital, goal, deadline and risk profile.
 - It now binds to `127.0.0.1` by default for improved security.

--- a/user_manual_2025-08-19.md
+++ b/user_manual_2025-08-19.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.37
+# User Manual v0.6.38
 
 Date: 2025-08-19
 
@@ -7,7 +7,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 ## Overview
 - Goal-based investment platform with daily actionable recommendations.
 - Redis cache infrastructure provides shared helpers for services.
-- See [development_tasks.md](development_tasks.md) for the current roadmap and task status.
+- See [development_tasks_2025-08-19.md](development_tasks_2025-08-19.md) for the current roadmap and task status.
 
 ## Services Overview
 - api-gateway
@@ -126,6 +126,12 @@ Each service now includes a `requirements.txt` file to facilitate Docker builds 
 - Install with `notification-service/install.sh` and remove with `notification-service/remove.sh` (v0.3.1).
 - Configure bind address via `NOTIFICATION_HOST` (default `127.0.0.1`) and `NOTIFICATION_PORT`.
 
+## Feasibility Calculator
+- FastAPI service exposing `/feasibility` endpoint for CAGR, daily returns and probability-of-hitting calculations.
+- Registered in `docker-compose.yml` with logs stored in `logs/feasibility-calculator.log`.
+- Install with `feasibility-calculator/install.sh` and remove with `feasibility-calculator/remove.sh` (v0.1.0).
+- See [development_tasks_2025-08-19.md](development_tasks_2025-08-19.md#mvp-deliverables) for planned enhancements.
+
 ## Backtester
 - Generate HTML performance reports from strategy configs.
 - Run `python backtester/cli.py --config config.json --start-date 2024-01-01 --end-date 2024-06-01`.
@@ -139,7 +145,7 @@ Each service now includes a `requirements.txt` file to facilitate Docker builds 
 ## UI
 - Next.js frontend with Tailwind CSS.
 - `/goals` page submits new goals to the API Gateway `/goals` endpoint.
- - `/daily-actions` page displays recommendations fetched from `/actions/today`.
+ - `/daily-actions` page displays recommendations fetched from `/actions/today` and allows order export via a checklist.
 - Install with `ui/install.sh` and remove with `ui/remove.sh` (v0.3.2).
 - Screenshots:
   - Goal creation page (screenshot omitted)


### PR DESCRIPTION
## Summary
- mark MVP deliverables complete and add follow-up items in dated task list
- document feasibility calculator service and UI export in user manuals
- log reviewed tasks in changelog under 2025-08-19

## Testing
- `npm run test:e2e` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68a5002d2054832cb047cc26112c6080