### PR TITLE
docs: reconcile tasks and update manuals

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.38
+# Changelog v0.6.39
 
 ## 2025-01-14
 - Added Playwright end-to-end tests under `tests/e2e` for UI and API flows.
@@ -120,6 +120,8 @@
 - Added `logs/mobile/` path to log creation scripts for mobile build artifacts.
 - Documented mobile and PWA features in user manuals.
 - Reviewed development tasks, marking feasibility calculator, action UI export and backtester HTML reports as complete with cross-references in user manuals.
+- Reconciled `development_tasks` with dated logs, adding deliverables for feasibility calculator documentation and backtester benchmarking.
+- Updated user manuals with notes on feasibility calculator integration and backtester performance plans.
 
 ## 2025-08-18
 - Added initial development tasks outline.

--- a/changelog_2025-08-19.md
+++ b/changelog_2025-08-19.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.35
+# Changelog v0.6.36
 
 ## 2025-08-19
 - Added shared monitoring utilities providing JSON logging, Prometheus metrics and OpenTelemetry traces.
@@ -81,6 +81,8 @@
 - Added `strategies` and `strategy_reviews` tables with migrations and schema checks.
 - Stored uploaded strategy files under `strategy-marketplace/assets/` with dedicated log directory.
 - Updated log creation scripts, `.gitignore` and documentation for the new service and installer scripts.
+- Reconciled `development_tasks` with dated logs, adding deliverables for feasibility calculator documentation and backtester benchmarking.
+- Updated user manual with notes on feasibility calculator integration and backtester performance plans.
 
 ## 2025-08-18
 - Added initial development tasks outline.

--- a/development_tasks.md
+++ b/development_tasks.md
@@ -1,4 +1,4 @@
-# Development Tasks v0.1.2
+# Development Tasks v0.1.3
 
 Date: 2025-08-19
 
@@ -26,8 +26,12 @@ Date: 2025-08-19
 - [x] Maintain `changelog` for every update with version and date.
 
 ## MVP Deliverables
-- [ ] Implement `feasibility-calculator` service (API + UI) for goal feasibility calculations.
-- [ ] Extend `actions` UI with checklist and export of orders.
-- [ ] Generate HTML reports in `backtester` CLI.
+- [x] Implement `feasibility-calculator` service (API + UI) for goal feasibility calculations. See [Feasibility Calculator](user_manual_2025-08-19.md#feasibility-calculator).
+- [x] Extend `actions` UI with checklist and export of orders. See [UI](user_manual_2025-08-19.md#ui).
+- [x] Generate HTML reports in `backtester` CLI. See [Backtester](user_manual_2025-08-19.md#backtester).
+- [ ] Integrate `feasibility-calculator` results into the UI overview. See [Feasibility Calculator](user_manual_2025-08-19.md#feasibility-calculator).
+- [ ] Implement automated tests for `feasibility-calculator` service. See [Feasibility Calculator](user_manual_2025-08-19.md#feasibility-calculator).
+- [ ] Document feasibility calculator integration workflow in `user_manual`. See [Feasibility Calculator](user_manual_2025-08-19.md#feasibility-calculator).
+- [ ] Add performance benchmarking for `backtester` simulations. See [Backtester](user_manual_2025-08-19.md#backtester).
 
 Refer to [user_manual_2025-08-19.md](user_manual_2025-08-19.md) for installation and usage details.

--- a/development_tasks_2025-08-19.md
+++ b/development_tasks_2025-08-19.md
@@ -1,4 +1,4 @@
-# Development Tasks v0.1.3
+# Development Tasks v0.1.4
 
 Date: 2025-08-19
 
@@ -31,5 +31,7 @@ Date: 2025-08-19
 - [x] Generate HTML reports in `backtester` CLI. See [Backtester](user_manual_2025-08-19.md#backtester).
 - [ ] Integrate feasibility calculator results into the UI overview. See [Feasibility Calculator](user_manual_2025-08-19.md#feasibility-calculator).
 - [ ] Implement automated tests for `feasibility-calculator` service. See [Feasibility Calculator](user_manual_2025-08-19.md#feasibility-calculator).
+- [ ] Document feasibility calculator integration workflow in `user_manual`. See [Feasibility Calculator](user_manual_2025-08-19.md#feasibility-calculator).
+- [ ] Add performance benchmarking for `backtester` simulations. See [Backtester](user_manual_2025-08-19.md#backtester).
 
 Refer to [user_manual_2025-08-19.md](user_manual_2025-08-19.md) for installation and usage details.

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.38
+# User Manual v0.6.39
 
 Date: 2025-08-19
 
@@ -64,7 +64,9 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Visualize aggregated metrics via the `/analytics` endpoint or the UI analytics page, which renders charts with Chart.js.
 - The feasibility-calculator service exposes `/feasibility` to estimate CAGR, daily returns and probability of hitting a target based on capital, goal, deadline and risk profile.
 - It now binds to `127.0.0.1` by default for improved security.
+- Work in progress: integrate results into the UI overview, document the workflow and add automated tests.
 - The backtester CLI loads prices from the database, simulates equal-weight portfolios, computes KPIs (CAGR, Sharpe, max drawdown), embeds equity charts in HTML reports and records metrics in the `backtests` table.
+- Planned: add performance benchmarking for simulations.
 - Risk engine additionally offers `/risk/stress` for historical and hypothetical scenario analysis with stored results.
 
 ### Strategy Engine

--- a/user_manual_2025-08-19.md
+++ b/user_manual_2025-08-19.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.38
+# User Manual v0.6.39
 
 Date: 2025-08-19
 
@@ -131,6 +131,7 @@ Each service now includes a `requirements.txt` file to facilitate Docker builds 
 - Registered in `docker-compose.yml` with logs stored in `logs/feasibility-calculator.log`.
 - Install with `feasibility-calculator/install.sh` and remove with `feasibility-calculator/remove.sh` (v0.1.0).
 - See [development_tasks_2025-08-19.md](development_tasks_2025-08-19.md#mvp-deliverables) for planned enhancements.
+- Upcoming: integrate results into the UI overview, document the workflow and add automated tests.
 
 ## Backtester
 - Generate HTML performance reports from strategy configs.
@@ -138,6 +139,7 @@ Each service now includes a `requirements.txt` file to facilitate Docker builds 
 - Use `--output` to specify report path; defaults to `backtester/reports`.
 - Flags: `--install` to prepare report directory, `--remove` to clean it`.
 - The CLI now pulls prices from the database, simulates equal-weight portfolios, outputs KPIs (CAGR, Sharpe, max drawdown) with embedded charts and writes metrics to the `backtests` table.
+- Planned: add performance benchmarking for simulations.
 
 ## Architecture
 - See README for initial specification.


### PR DESCRIPTION
## Summary
- align development tasks with dated logs and add new deliverables
- document feasibility calculator integration and backtester benchmarking
- record updates in changelog entries

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a50b19195c832cae2163be38137cc9