### PR TITLE
feat: add interactive Windows installer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.40
+# Changelog v0.6.41
 
 ## 2025-01-14
 - Added Playwright end-to-end tests under `tests/e2e` for UI and API flows.
@@ -187,6 +187,7 @@
 - Updated services to persist and query data by `tenant_id`.
 - Documented tenant scoping in user manuals and bumped service versions.
 - Introduced Monte Carlo simulation utilities in strategy-engine with probability-of-hitting calculations.
+- Added interactive Windows installer `setup_full.cmd` with SQL database creation and `remove_full.cmd` for teardown; documented in user manual.
 - Core and satellite strategies now derive signals from market data, adjust risk via the risk engine, and justify allocations through `explain()`.
 - Extended strategy interface with `explain()` and added tests and documentation for dynamic weights.
 

--- a/remove_full.cmd
+++ b/remove_full.cmd
@@ -1,0 +1,35 @@
+@echo off
+rem remove_full.cmd v0.1.0 (2025-08-20)
+
+echo CashMachiine full removal
+
+echo.
+set /p DB_HOST="Enter database host [localhost]: "
+if "%DB_HOST%"=="" set DB_HOST=localhost
+set /p DB_PORT="Enter database port [5432]: "
+if "%DB_PORT%"=="" set DB_PORT=5432
+set /p DB_NAME="Enter database name [cashmachiine]: "
+if "%DB_NAME%"=="" set DB_NAME=cashmachiine
+set /p DB_USER="Enter database user [postgres]: "
+if "%DB_USER%"=="" set DB_USER=postgres
+set /p DB_PASS="Enter database password: "
+
+echo Dropping tables...
+set PGPASSWORD=%DB_PASS%
+for %%T in (actions backtests metrics_daily risk_limits signals prices executions orders positions portfolios accounts goals users) do (
+  echo Dropping %%T
+  psql -h %DB_HOST% -p %DB_PORT% -U %DB_USER% -d %DB_NAME% -c "DROP TABLE IF EXISTS %%T CASCADE;"
+)
+set PGPASSWORD=
+
+echo Uninstalling Python dependencies...
+pip uninstall -r "%~dp0requirements.txt" -y
+
+where docker >nul 2>nul
+if %ERRORLEVEL%==0 (
+  docker compose down 2>nul || docker-compose down
+) else (
+  echo Docker not found, skipping container stop.
+)
+
+echo Removal complete.

--- a/setup_full.cmd
+++ b/setup_full.cmd
@@ -1,0 +1,43 @@
+@echo off
+rem setup_full.cmd v0.1.0 (2025-08-20)
+
+echo CashMachiine full interactive setup
+
+echo.
+set /p DB_HOST="Enter database host [localhost]: "
+if "%DB_HOST%"=="" set DB_HOST=localhost
+set /p DB_PORT="Enter database port [5432]: "
+if "%DB_PORT%"=="" set DB_PORT=5432
+set /p DB_NAME="Enter database name [cashmachiine]: "
+if "%DB_NAME%"=="" set DB_NAME=cashmachiine
+set /p DB_USER="Enter database user [postgres]: "
+if "%DB_USER%"=="" set DB_USER=postgres
+set /p DB_PASS="Enter database password: "
+
+echo Installing Python dependencies...
+pip install -r "%~dp0requirements.txt"
+
+if not exist .env (
+  echo Creating .env from sample...
+  copy .env.example .env >nul
+)
+
+echo Creating and migrating database...
+set PGPASSWORD=%DB_PASS%
+psql -h %DB_HOST% -p %DB_PORT% -U %DB_USER% -tc "SELECT 1 FROM pg_database WHERE datname='%DB_NAME%';" | findstr 1 >nul || psql -h %DB_HOST% -p %DB_PORT% -U %DB_USER% -c "CREATE DATABASE %DB_NAME%"
+psql -h %DB_HOST% -p %DB_PORT% -U %DB_USER% -d %DB_NAME% -c "CREATE EXTENSION IF NOT EXISTS timescaledb;"
+for %%f in (db\migrations\*.sql) do (
+  echo Applying %%f
+  psql -h %DB_HOST% -p %DB_PORT% -U %DB_USER% -d %DB_NAME% -f %%f
+)
+set PGPASSWORD=
+
+echo Starting services with Docker...
+where docker >nul 2>nul
+if %ERRORLEVEL%==0 (
+  docker compose up -d 2>nul || docker-compose up -d
+) else (
+  echo Docker not found, skipping container start.
+)
+
+echo Setup complete.

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,6 +1,6 @@
-# User Manual v0.6.40
+# User Manual v0.6.41
 
-Date: 2025-08-19
+Date: 2025-08-20
 
 This document will evolve into a comprehensive encyclopedia for the project.
 
@@ -11,6 +11,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Copy `.env.example` to `.env` and adjust values as needed, including `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, `RATE_LIMIT_PER_MINUTE`, `ALPHA_VANTAGE_KEY`, `BINANCE_API_KEY`, `BINANCE_API_SECRET` and `IBKR_API_KEY`.
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
+- Run `setup_full.cmd` for an interactive Windows setup including database creation; use `remove_full.cmd` to uninstall and drop tables.
 - Each service provides `install.sh` and `remove.sh` scripts.
 - Each service now ships with its own `requirements.txt` for Docker builds.
 - Backtester includes a dedicated `requirements.txt` to ensure image builds succeed.


### PR DESCRIPTION
## Summary
- add interactive `setup_full.cmd` to install dependencies, create TimescaleDB database and start containers
- add `remove_full.cmd` to drop tables, uninstall dependencies and stop containers
- document full Windows setup in user manual and changelog

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a51032a48c832cb5bf96e12e3a0ef6