### PR TITLE
feat: add audit log service for domain events

### DIFF
--- a/admin/db_check.php
+++ b/admin/db_check.php
@@ -1,6 +1,6 @@
 <?php
-// db_check.php v0.1.11 (2025-08-20)
-$expectedVersion = 'v0.1.8';
+// db_check.php v0.1.12 (2025-08-20)
+$expectedVersion = 'v0.1.9';
 $dsn = sprintf('pgsql:host=%s;port=%s;dbname=%s',
     getenv('DB_HOST') ?: 'localhost',
     getenv('DB_PORT') ?: '5432',
@@ -10,7 +10,7 @@ $pass = getenv('DB_PASS') ?: '';
 $requiredTables = [
     'users','goals','accounts','portfolios','positions','orders',
     'executions','prices','signals','actions','risk_limits','metrics_daily',
-    'backtests','risk_stress_results','notifications','strategies','strategy_reviews'
+    'backtests','risk_stress_results','notifications','strategies','strategy_reviews','audit_events'
 ];
 $warehouseTables = ['dw_orders','dw_positions'];
 $priceColumns = ['symbol','venue','ts','o','h','l','c','v'];
@@ -34,7 +34,7 @@ foreach ($warehouseTables as $tbl) {
         exit(1);
     }
 }
-$tenantTables = ['users','goals','orders'];
+$tenantTables = ['users','goals','orders','audit_events'];
 foreach ($tenantTables as $tbl) {
     $stmt = $pdo->query("SELECT column_name FROM information_schema.columns WHERE table_name='$tbl'");
     $cols = $stmt->fetchAll(PDO::FETCH_COLUMN);

--- a/api-gateway/tests/test_main.py
+++ b/api-gateway/tests/test_main.py
@@ -17,6 +17,7 @@ MODULE_PATH = Path(__file__).resolve().parents[1] / "main.py"
 SPEC = importlib.util.spec_from_file_location("api_gateway_main", MODULE_PATH)
 main = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(main)
+main.emit_event = lambda *args, **kwargs: None
 
 SECRET_KEY = main.SECRET_KEY
 ALGORITHM = main.ALGORITHM
@@ -37,7 +38,7 @@ def test_goals_returns_version_header_and_data():
     token = create_token("user")
     response = client.get("/goals", headers={"Authorization": f"Bearer {token}"})
     assert response.status_code == 200  # nosec
-    assert response.headers["X-API-Version"] == "v0.2.9"  # nosec
+    assert response.headers["X-API-Version"] == "v0.2.10"  # nosec
     assert response.json() == {"goals": []}  # nosec
 
 

--- a/audit-log/Dockerfile
+++ b/audit-log/Dockerfile
@@ -1,0 +1,7 @@
+# Dockerfile v0.1.0 (2025-08-20)
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir --disable-pip-version-check --root-user-action=ignore -r requirements.txt
+COPY . .
+CMD ["python", "audit-log/main.py"]

--- a/audit-log/__init__.py
+++ b/audit-log/__init__.py
@@ -1,0 +1,2 @@
+"""audit-log service v0.1.0 (2025-08-20)"""
+__version__ = "0.1.0"

--- a/audit-log/install.sh
+++ b/audit-log/install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# audit-log installer v0.1.0
+echo "Installing audit-log service..."
+pip install --no-cache-dir --disable-pip-version-check --root-user-action=ignore -r requirements.txt >/dev/null
+mkdir -p "$(dirname "$0")/logs"

--- a/audit-log/main.py
+++ b/audit-log/main.py
@@ -1,0 +1,39 @@
+"""audit-log consumer v0.1.0 (2025-08-20)"""
+import argparse
+import json
+import psycopg2
+from messaging import EventConsumer
+from common.monitoring import setup_logging
+from config import settings
+
+logger = setup_logging("audit-log", remote_url=settings.remote_log_url)
+
+def handle_event(message: dict) -> None:
+    event = message.get("event")
+    payload = json.dumps(message.get("payload"))
+    with psycopg2.connect(
+        host=settings.db_host,
+        port=settings.db_port,
+        dbname=settings.db_name,
+        user=settings.db_user,
+        password=settings.db_pass,
+    ) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO audit_events (event, payload, tenant_id) VALUES (%s,%s,%s)",
+                (event, payload, message.get("payload", {}).get("tenant_id", 1)),
+            )
+            conn.commit()
+    logger.info("Logged %s", event)
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="audit-log consumer v0.1.0")
+    parser.parse_args()
+    consumer = EventConsumer(settings.rabbitmq_url, queue="audit-log")
+    try:
+        consumer.start(handle_event)
+    finally:
+        consumer.close()
+
+if __name__ == "__main__":
+    main()

--- a/audit-log/remove.sh
+++ b/audit-log/remove.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# audit-log removal v0.1.0
+echo "Removing audit-log service..."
+pip uninstall -y -r requirements.txt >/dev/null 2>&1

--- a/audit-log/requirements.txt
+++ b/audit-log/requirements.txt
@@ -1,0 +1,6 @@
+# requirements.txt v0.1.0 (2025-08-20)
+psycopg2-binary>=2.9.9
+prometheus-client>=0.20.0
+opentelemetry-sdk>=1.24.0
+python-dotenv>=1.0.1
+pika>=1.3.2

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.42
+# Changelog v0.6.43
 
 ## 2025-01-14
 - Added Playwright end-to-end tests under `tests/e2e` for UI and API flows.
@@ -192,5 +192,6 @@
 - Extended strategy interface with `explain()` and added tests and documentation for dynamic weights.
 
 - Added broker fee and tax calculations with DB columns and net order metrics returned by api-gateway.
+- Added audit-log service capturing domain events in `audit_events` with producer helpers and replay docs.
 
 

--- a/changelog_2025-08-20.md
+++ b/changelog_2025-08-20.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.10
+# Changelog v0.6.11
 
 ## 2025-02-14
 - Introduced user manual revision with installation, usage, architecture and troubleshooting sections.
@@ -95,4 +95,5 @@
 - Extended JWT payloads and API gateway RBAC to enforce tenant scoping.
 - Updated services to persist and query data by `tenant_id`.
 - Documented tenant scoping in user manuals and bumped service versions.
+- Added audit-log service capturing domain events in `audit_events` with producer helpers and replay docs.
 

--- a/common/__init__.py
+++ b/common/__init__.py
@@ -1,4 +1,4 @@
-"""Common utilities package v0.1.2 (2025-08-19)"""
-__version__ = "0.1.2"
+"""Common utilities package v0.1.3 (2025-08-20)"""
+__version__ = "0.1.3"
 
-__all__ = ["monitoring"]
+__all__ = ["monitoring", "events"]

--- a/common/events.py
+++ b/common/events.py
@@ -1,0 +1,17 @@
+"""Event helpers v0.1.0 (2025-08-20)"""
+from messaging import EventProducer
+from config import settings
+
+_producer: EventProducer | None = None
+
+def get_event_producer() -> EventProducer:
+    """Return a singleton RabbitMQ event producer."""
+    global _producer
+    if _producer is None:
+        _producer = EventProducer(settings.rabbitmq_url)
+    return _producer
+
+def emit_event(event: str, payload: dict) -> None:
+    """Publish an event with the given payload."""
+    producer = get_event_producer()
+    producer.publish(event, payload)

--- a/db/migrations/022_create_audit_events.sql
+++ b/db/migrations/022_create_audit_events.sql
@@ -1,0 +1,8 @@
+-- 022_create_audit_events.sql v0.1.0 (2025-08-20)
+CREATE TABLE IF NOT EXISTS audit_events (
+    id SERIAL PRIMARY KEY,
+    event VARCHAR(50) NOT NULL,
+    payload JSONB NOT NULL,
+    tenant_id INTEGER NOT NULL DEFAULT 1,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# docker-compose.yml v0.1.3 (2025-08-19)
+# docker-compose.yml v0.1.4 (2025-08-20)
 version: '3.8'
 services:
   db:
@@ -59,6 +59,13 @@ services:
     depends_on:
       - db
       - cache
+      - rabbitmq
+  audit-log:
+    build:
+      context: .
+      dockerfile: audit-log/Dockerfile
+    depends_on:
+      - db
       - rabbitmq
   backtester:
     build:

--- a/execution-engine/tests/test_order_handler.py
+++ b/execution-engine/tests/test_order_handler.py
@@ -64,6 +64,7 @@ def test_order_persistence(monkeypatch):
         return FakeConn(executed)
 
     monkeypatch.setattr(order_handler_mod.psycopg2, "connect", fake_connect)
+    monkeypatch.setattr(order_handler_mod, "emit_event", lambda *a, **k: None)
 
     redis_client = fakeredis.FakeRedis()
     handler = OrderHandler(redis_client=redis_client)

--- a/remove_db.sh
+++ b/remove_db.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# remove_db.sh v0.1.0
+# remove_db.sh v0.1.1 (2025-08-20)
 set -e
-TABLES=(actions backtests metrics_daily risk_limits signals prices executions orders positions portfolios accounts goals users)
+TABLES=(actions backtests metrics_daily risk_limits signals prices executions orders positions portfolios accounts goals users audit_events)
 for tbl in "${TABLES[@]}"; do
   echo "Dropping $tbl"
   psql "$@" -c "DROP TABLE IF EXISTS $tbl CASCADE;"

--- a/remove_full.cmd
+++ b/remove_full.cmd
@@ -1,5 +1,5 @@
 @echo off
-rem remove_full.cmd v0.1.0 (2025-08-20)
+rem remove_full.cmd v0.1.1 (2025-08-20)
 
 echo CashMachiine full removal
 
@@ -16,7 +16,7 @@ set /p DB_PASS="Enter database password: "
 
 echo Dropping tables...
 set PGPASSWORD=%DB_PASS%
-for %%T in (actions backtests metrics_daily risk_limits signals prices executions orders positions portfolios accounts goals users) do (
+for %%T in (actions backtests metrics_daily risk_limits signals prices executions orders positions portfolios accounts goals users audit_events) do (
   echo Dropping %%T
   psql -h %DB_HOST% -p %DB_PORT% -U %DB_USER% -d %DB_NAME% -c "DROP TABLE IF EXISTS %%T CASCADE;"
 )

--- a/tools/log_create.sh
+++ b/tools/log_create.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# log directory creator v0.6.18 (2025-08-19)
+# log directory creator v0.6.19 (2025-08-20)
 set -e
 mkdir -p logs
 mkdir -p logs/containers
@@ -18,6 +18,7 @@ mkdir -p logs/data-warehouse
 mkdir -p strategy-engine/models
 mkdir -p strategy-marketplace/assets
 mkdir -p backups
+mkdir -p logs/audit-log
 touch logs/orchestrator.log
 touch logs/data-ingestion.log
 touch logs/strategy-engine.log
@@ -32,3 +33,4 @@ touch logs/fx-service/fx.log
 touch execution-engine/logs/orders.log
 touch logs/mobile/build.log
 touch logs/data-warehouse/etl.log
+touch logs/audit-log/audit.log

--- a/tools/log_create_win.cmd
+++ b/tools/log_create_win.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM log directory creator v0.6.18 (2025-08-19)
+REM log directory creator v0.6.19 (2025-08-20)
 mkdir logs 2>nul
 mkdir logs\containers 2>nul
 mkdir logs\analytics 2>nul
@@ -17,6 +17,7 @@ mkdir logs\data-warehouse 2>nul
 mkdir strategy-engine\models 2>nul
 mkdir strategy-marketplace\assets 2>nul
 mkdir backups 2>nul
+mkdir logs\audit-log 2>nul
 type nul > logs\orchestrator.log
 type nul > logs\data-ingestion.log
 type nul > logs\strategy-engine.log
@@ -31,3 +32,4 @@ type nul > logs\fx-service\fx.log
 type nul > execution-engine\logs\orders.log
 type nul > logs\mobile\build.log
 type nul > logs\data-warehouse\etl.log
+type nul > logs\audit-log\audit.log

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.42
+# User Manual v0.6.43
 
 Date: 2025-08-20
 
@@ -45,6 +45,10 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Nightly ETL scripts load operational data into an analytical `warehouse` schema.
 - Logs reside in `logs/data-warehouse/etl.log`.
 - Install with `data-warehouse/install.sh` and remove with `data-warehouse/remove.sh` (v0.1.0).
+
+## Audit Log
+- The `audit-log` service consumes RabbitMQ events and stores them in the `audit_events` table.
+- Replay system state by fetching events ordered by `id` and re-emitting them via `common.events.emit_event`.
 
 ## Usage
 - Authenticate and interact with the API Gateway at `/goals`, `/goals/{id}/status`, `/actions/today`, `/actions/{id}/check` and `/orders/preview`. Requests are scoped by the `tenant_id` embedded in JWT tokens.

--- a/user_manual_2025-08-20.md
+++ b/user_manual_2025-08-20.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.12
+# User Manual v0.6.13
 
 Date: 2025-08-20
 
@@ -22,6 +22,10 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Pass `--install` or `--remove` to service scripts for setup and teardown.
 - The UI supports French and English; append `/en` to URLs to switch to English.
 - The feasibility-calculator service exposes `/feasibility` to estimate CAGR, daily returns and probability of hitting a target based on capital, goal, deadline and risk profile.
+
+## Audit Log
+- The `audit-log` service records domain events in the `audit_events` table.
+- Replay state by selecting events ordered by `id` and republishing them with `common.events.emit_event`.
 
 ### Strategy Engine
 - `strategy-engine` includes `simulation.py` for Monte Carlo path generation and probability-of-hitting analysis.


### PR DESCRIPTION
## Summary
- add audit-log service consuming RabbitMQ events and persisting to `audit_events`
- emit domain events via common helpers from API gateway and execution engine
- document replay mechanics and update scripts and schema checks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a52a07fc54832c973c5b57c2baa9c8