### PR TITLE
feat: add offline caching and push notifications

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.43
+# Changelog v0.6.44
 
 ## 2025-01-14
 - Added Playwright end-to-end tests under `tests/e2e` for UI and API flows.
@@ -193,5 +193,6 @@
 
 - Added broker fee and tax calculations with DB columns and net order metrics returned by api-gateway.
 - Added audit-log service capturing domain events in `audit_events` with producer helpers and replay docs.
-
-
+- Implemented service workers and localStorage caches in mobile and UI.
+- Integrated push notifications via notification-service and client APIs.
+- Updated install scripts and log creation scripts for new components.

--- a/changelog_2025-08-20.md
+++ b/changelog_2025-08-20.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.11
+# Changelog v0.6.12
 
 ## 2025-02-14
 - Introduced user manual revision with installation, usage, architecture and troubleshooting sections.
@@ -96,4 +96,6 @@
 - Updated services to persist and query data by `tenant_id`.
 - Documented tenant scoping in user manuals and bumped service versions.
 - Added audit-log service capturing domain events in `audit_events` with producer helpers and replay docs.
-
+- Implemented service workers and localStorage caches in mobile and UI.
+- Integrated push notifications via notification-service and client APIs.
+- Updated install scripts and log creation scripts for new components.

--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,11 +1,44 @@
-// App v0.1.0 (2025-08-19)
-import React from 'react';
+// App v0.1.1 (2025-08-20)
+import React, { useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 
 export default function App() {
+  const [message, setMessage] = useState('CashMachiine Mobile');
+
+  useEffect(() => {
+    if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
+      navigator.serviceWorker
+        .register('/service-worker.js')
+        .then(reg => {
+          if (typeof Notification !== 'undefined') {
+            Notification.requestPermission().then(permission => {
+              if (permission === 'granted') {
+                reg.pushManager
+                  .subscribe({ userVisibleOnly: true })
+                  .then(sub => {
+                    fetch('http://localhost:8000/notify/push', {
+                      method: 'POST',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify({ user_id: 0, subscription: sub }),
+                    }).catch(() => {});
+                  })
+                  .catch(() => {});
+              }
+            });
+          }
+        })
+        .catch(() => {});
+    }
+    if (typeof localStorage !== 'undefined') {
+      const cached = localStorage.getItem('welcome');
+      if (cached) setMessage(cached);
+      else localStorage.setItem('welcome', message);
+    }
+  }, [message]);
+
   return (
     <View>
-      <Text>CashMachiine Mobile</Text>
+      <Text>{message}</Text>
     </View>
   );
 }

--- a/mobile/index.js
+++ b/mobile/index.js
@@ -1,4 +1,4 @@
-// Entry v0.1.0 (2025-08-19)
+// Entry v0.1.1 (2025-08-20)
 import { AppRegistry } from 'react-native';
 import App from './App';
 

--- a/mobile/install.sh
+++ b/mobile/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mobile installer v0.1.0 (2025-08-19)
+# mobile installer v0.1.1 (2025-08-20)
 set -e
 cd "$(dirname "$0")"
 npm install

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cashmachiine-mobile",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "start": "react-native start",

--- a/mobile/remove.sh
+++ b/mobile/remove.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# mobile removal v0.1.0 (2025-08-19)
+# mobile removal v0.1.1 (2025-08-20)
 set -e
 cd "$(dirname "$0")"
 rm -rf node_modules android ios

--- a/mobile/service-worker.js
+++ b/mobile/service-worker.js
@@ -1,0 +1,22 @@
+// mobile service worker v0.1.0 (2025-08-20)
+const CACHE_NAME = 'mobile-cache-v1';
+const OFFLINE_URLS = ['/'];
+self.addEventListener('install', event => {
+  self.skipWaiting();
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(OFFLINE_URLS))
+  );
+});
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});
+self.addEventListener('push', event => {
+  const data = event.data?.json() || {};
+  event.waitUntil(
+    self.registration.showNotification(data.title || 'CashMachiine', {
+      body: data.body || 'Notification'
+    })
+  );
+});

--- a/notification-service/__init__.py
+++ b/notification-service/__init__.py
@@ -1,2 +1,2 @@
-"""notification-service v0.3.1 (2025-08-19)"""
-__version__ = "0.3.1"
+"""notification-service v0.3.2 (2025-08-20)"""
+__version__ = "0.3.2"

--- a/notification-service/install.sh
+++ b/notification-service/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# notification-service installer v0.3.1
+# notification-service installer v0.3.2 (2025-08-20)
 echo "Installing notification-service service..."
 pip install --no-cache-dir --disable-pip-version-check --root-user-action=ignore -r requirements.txt >/dev/null
 mkdir -p "$(dirname "$0")/../logs/notification-service"

--- a/notification-service/remove.sh
+++ b/notification-service/remove.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# notification-service removal v0.3.1
+# notification-service removal v0.3.2 (2025-08-20)
 echo "Removing notification-service service..."
 pip uninstall -y -r requirements.txt >/dev/null 2>&1

--- a/notification-service/requirements.txt
+++ b/notification-service/requirements.txt
@@ -1,4 +1,4 @@
-# requirements.txt v0.1.0 (2025-08-19)
+# requirements.txt v0.1.1 (2025-08-20)
 requests>=2.31.0
 fastapi>=0.110.0
 uvicorn>=0.29.0
@@ -13,3 +13,4 @@ opentelemetry-sdk>=1.24.0
 python-dotenv>=1.0.1
 redis>=5.0.0
 pika>=1.3.2
+pywebpush>=1.14.0

--- a/tools/log_create.sh
+++ b/tools/log_create.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# log directory creator v0.6.19 (2025-08-20)
+# log directory creator v0.6.20 (2025-08-20)
 set -e
 mkdir -p logs
 mkdir -p logs/containers
@@ -14,6 +14,7 @@ mkdir -p logs/notification-service
 mkdir -p logs/strategy-marketplace
 mkdir -p logs/fx-service
 mkdir -p logs/mobile
+mkdir -p logs/ui
 mkdir -p logs/data-warehouse
 mkdir -p strategy-engine/models
 mkdir -p strategy-marketplace/assets
@@ -32,5 +33,6 @@ touch logs/strategy-marketplace/marketplace.log
 touch logs/fx-service/fx.log
 touch execution-engine/logs/orders.log
 touch logs/mobile/build.log
+touch logs/ui/build.log
 touch logs/data-warehouse/etl.log
 touch logs/audit-log/audit.log

--- a/tools/log_create_win.cmd
+++ b/tools/log_create_win.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM log directory creator v0.6.19 (2025-08-20)
+REM log directory creator v0.6.20 (2025-08-20)
 mkdir logs 2>nul
 mkdir logs\containers 2>nul
 mkdir logs\analytics 2>nul
@@ -13,6 +13,7 @@ mkdir logs\notification-service 2>nul
 mkdir logs\strategy-marketplace 2>nul
 mkdir logs\fx-service 2>nul
 mkdir logs\mobile 2>nul
+mkdir logs\ui 2>nul
 mkdir logs\data-warehouse 2>nul
 mkdir strategy-engine\models 2>nul
 mkdir strategy-marketplace\assets 2>nul
@@ -31,5 +32,6 @@ type nul > logs\strategy-marketplace\marketplace.log
 type nul > logs\fx-service\fx.log
 type nul > execution-engine\logs\orders.log
 type nul > logs\mobile\build.log
+type nul > logs\ui\build.log
 type nul > logs\data-warehouse\etl.log
 type nul > logs\audit-log\audit.log

--- a/ui/install.sh
+++ b/ui/install.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-# ui installer v0.3.3 (2025-08-19)
+# ui installer v0.3.4 (2025-08-20)
 set -e
 cd "$(dirname "$0")"
 npm install
 ./install_locales.sh
-

--- a/ui/lib/push.js
+++ b/ui/lib/push.js
@@ -1,0 +1,12 @@
+/** Push helper v0.1.0 (2025-08-20) */
+export async function registerPush(reg) {
+  if (!('Notification' in window)) return;
+  const perm = await Notification.requestPermission();
+  if (perm !== 'granted') return;
+  const sub = await reg.pushManager.subscribe({ userVisibleOnly: true });
+  await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000'}/notify/push`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_id: 0, subscription: sub }),
+  }).catch(() => {});
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cashmachiine-ui",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/ui/pages/_app.js
+++ b/ui/pages/_app.js
@@ -1,8 +1,18 @@
-/** Custom App v0.2.1 (2025-08-19) */
+/** Custom App v0.2.2 (2025-08-20) */
+import { useEffect } from 'react';
 import Head from 'next/head';
 import '../styles/globals.css';
+import { registerPush } from '../lib/push';
 
 export default function App({ Component, pageProps }) {
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker
+        .register('/service-worker.js')
+        .then(reg => registerPush(reg))
+        .catch(() => {});
+    }
+  }, []);
   return (
     <>
       <Head>

--- a/ui/pages/daily-actions.js
+++ b/ui/pages/daily-actions.js
@@ -1,4 +1,4 @@
-/** Daily actions page v0.3.0 (2025-08-19) */
+/** Daily actions page v0.3.1 (2025-08-20) */
 import { useEffect, useState } from 'react';
 import { useTranslation } from '../lib/useTranslation';
 
@@ -9,17 +9,26 @@ export default function DailyActions() {
   const [message, setMessage] = useState('');
 
   useEffect(() => {
+    const cached = localStorage.getItem('actions');
+    if (cached) setActions(JSON.parse(cached));
     fetch(`${base}/actions`)
       .then(res => res.json())
-      .then(data => setActions(data.actions || []))
-      .catch(() => setActions([]));
+      .then(data => {
+        setActions(data.actions || []);
+        localStorage.setItem('actions', JSON.stringify(data.actions || []));
+      })
+      .catch(() => {});
   }, [base]);
 
   const check = id => {
     fetch(`${base}/actions/${id}/check`, { method: 'POST' })
       .then(res => {
         if (!res.ok) throw new Error('failed');
-        setActions(as => as.map(a => a.id === id ? { ...a, done: true } : a));
+        setActions(as => {
+          const updated = as.map(a => a.id === id ? { ...a, done: true } : a);
+          localStorage.setItem('actions', JSON.stringify(updated));
+          return updated;
+        });
         setMessage(t('daily.checked'));
       })
       .catch(() => setMessage(t('daily.error')));

--- a/ui/public/service-worker.js
+++ b/ui/public/service-worker.js
@@ -1,0 +1,17 @@
+/* ui service worker v0.3.5 (2025-08-20) */
+const CACHE_NAME = 'ui-cache-v1';
+const OFFLINE_URLS = ['/'];
+self.addEventListener('install', event => {
+  event.waitUntil(caches.open(CACHE_NAME).then(cache => cache.addAll(OFFLINE_URLS)));
+});
+self.addEventListener('fetch', event => {
+  event.respondWith(caches.match(event.request).then(r => r || fetch(event.request)));
+});
+self.addEventListener('push', event => {
+  const data = event.data?.json() || {};
+  event.waitUntil(
+    self.registration.showNotification(data.title || 'CashMachiine', {
+      body: data.body || 'Notification'
+    })
+  );
+});

--- a/ui/remove.sh
+++ b/ui/remove.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-# ui removal v0.3.3 (2025-08-19)
+# ui removal v0.3.4 (2025-08-20)
 set -e
 cd "$(dirname "$0")"
 rm -rf node_modules .next
 ./remove_locales.sh
-

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.43
+# User Manual v0.6.44
 
 Date: 2025-08-20
 
@@ -32,11 +32,11 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Use `./teardown_tf.sh` to destroy deployed resources, writing output to the same log directory.
 
 ## Progressive Web App
-- The Next.js UI registers a service worker and offline cache via `next-pwa`.
+- The Next.js UI registers a service worker for offline caching, stores daily actions in localStorage and subscribes to push notifications via notification-service.
 - A web app manifest lives at `ui/public/manifest.json`.
 
 ## Mobile Application
-- React Native app initialized under `mobile/` with a simple entry point.
+- React Native app initializes under `mobile/`, registers a service worker when available, caches a welcome message in localStorage and subscribes to push notifications via notification-service.
 - Use `mobile/build.sh` to generate mobile build logs in `logs/mobile/`.
 - Orders now store `fee` and `tax` columns with strategy-engine utilities computing broker costs.
 - API Gateway `/orders/preview` endpoint returns gross and net totals including fees and taxes.

--- a/user_manual_2025-08-20.md
+++ b/user_manual_2025-08-20.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.13
+# User Manual v0.6.14
 
 Date: 2025-08-20
 
@@ -22,6 +22,9 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Pass `--install` or `--remove` to service scripts for setup and teardown.
 - The UI supports French and English; append `/en` to URLs to switch to English.
 - The feasibility-calculator service exposes `/feasibility` to estimate CAGR, daily returns and probability of hitting a target based on capital, goal, deadline and risk profile.
+
+## Offline & Notifications
+- The UI and mobile app register service workers, cache data in localStorage and subscribe to push notifications through notification-service.
 
 ## Audit Log
 - The `audit-log` service records domain events in the `audit_events` table.


### PR DESCRIPTION
## Summary
- add service workers and localStorage caches to mobile and web UI
- integrate notification-service push endpoint with browser and mobile APIs
- update install scripts, log creation scripts, manuals and changelogs

## Testing
- `pytest`
- `cd mobile && npm test`
- `cd ui && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a530031e2c832cbfcbd43121b75ce2