### PR TITLE
Add Locust performance tests and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# ci.yml v0.2.1 (2025-01-14)
+# ci.yml v0.2.2 (2025-08-20)
 name: CI
 
 on:
@@ -73,9 +73,28 @@ jobs:
       - name: Run e2e tests
         run: npm run test:e2e
 
-  build:
+  performance:
     runs-on: ubuntu-latest
     needs: e2e
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run performance tests
+        run: ./tests/perf/run_perf.sh
+      - name: Upload performance reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-reports
+          path: perf/reports
+
+  build:
+    runs-on: ubuntu-latest
+    needs: performance
     strategy:
       matrix:
         service: [api-gateway, orchestrator, data-ingestion, strategy-engine, risk-engine, execution-engine, backtester, ui]

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# .gitignore v0.2.20 (2025-08-19)
+# .gitignore v0.2.21 (2025-08-20)
 # Python artifacts
 __pycache__/
 *.py[cod]
@@ -47,7 +47,7 @@ backups/*
 backtester/reports/
 tests/e2e/reports/*
 !tests/e2e/reports/.gitkeep
-perf/
+/perf/
 execution-engine/logs/
 strategy-engine/models/*
 !strategy-engine/models/.gitkeep

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.47
+# Changelog v0.6.48
 
 ## 2025-01-14
 - Added Playwright end-to-end tests under `tests/e2e` for UI and API flows.
@@ -202,3 +202,4 @@
 - Added `kyc_level` column migration on `users` with schema check updates and bumped expected DB version.
 - Wired API gateway onboarding endpoints to proxy uploads and status queries to kyc-service.
 - Expanded log creation scripts, docker-compose, environment samples, requirements and manuals for KYC integration.
+- Added Locust performance tests for api-gateway and strategy-engine with CI integration and reports under `perf/`.

--- a/changelog_2025-08-20.md
+++ b/changelog_2025-08-20.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.14
+# Changelog v0.6.15
 
 ## 2025-02-14
 - Introduced user manual revision with installation, usage, architecture and troubleshooting sections.
@@ -101,3 +101,4 @@
 - Updated install scripts and log creation scripts for new components.
 - Added Uniswap DeFi price fetcher and trade adapter with Web3 dependency, installer updates and new execution-engine logs; documented DeFi support in user manuals.
 - Introduced reinforcement learning allocation optimizer using Stable Baselines3 with models saved under `strategy-engine/models/` and integrated `optimize_allocation` into the strategy workflow; updated log scripts and documentation.
+- Added Locust performance tests for api-gateway and strategy-engine with CI integration and reports under `perf/`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# requirements.txt v0.3.11 (2025-08-20)
+# requirements.txt v0.3.12 (2025-08-20)
 
 # Runtime dependencies
 requests>=2.31.0
@@ -31,3 +31,5 @@ fakeredis>=2.21.0
 bandit>=1.7.5
 pytest-benchmark>=4.0.0
 playwright>=1.41.1
+locust>=2.29.0
+

--- a/tests/perf/locust_api_gateway.py
+++ b/tests/perf/locust_api_gateway.py
@@ -1,0 +1,20 @@
+"""Locust load test for api-gateway v0.1.0 (2025-08-20)"""
+from locust import HttpUser, task, between, events
+import os
+
+THRESHOLD_MS = float(os.getenv("API_GATEWAY_THRESHOLD_MS", "500"))
+
+class ApiGatewayUser(HttpUser):
+    wait_time = between(1, 2)
+    host = os.getenv("API_GATEWAY_URL", "http://localhost:8000")
+
+    @task
+    def docs(self):
+        self.client.get("/docs")
+
+@events.quitting.add_listener
+def _(environment, **kw):
+    avg = environment.stats.total.avg_response_time
+    if avg > THRESHOLD_MS:
+        print(f"Average response time {avg:.2f} ms exceeded threshold {THRESHOLD_MS} ms")
+        environment.process_exit_code = 1

--- a/tests/perf/locust_strategy_engine.py
+++ b/tests/perf/locust_strategy_engine.py
@@ -1,0 +1,31 @@
+"""Locust performance test for strategy-engine computations v0.1.0 (2025-08-20)"""
+from locust import User, task, between, events
+import time
+import os
+from strategies.core import CoreStrategy
+
+THRESHOLD_MS = float(os.getenv("STRATEGY_ENGINE_THRESHOLD_MS", "100"))
+
+class StrategyEngineUser(User):
+    wait_time = between(1, 2)
+
+    @task
+    def compute(self):
+        start = time.time()
+        strategy = CoreStrategy()
+        signals = strategy.signals([])
+        strategy.target_weights(signals)
+        total_time = (time.time() - start) * 1000
+        events.request_success.fire(
+            request_type="compute",
+            name="core_strategy",
+            response_time=total_time,
+            response_length=0,
+        )
+
+@events.quitting.add_listener
+def _(environment, **kw):
+    avg = environment.stats.total.avg_response_time
+    if avg > THRESHOLD_MS:
+        print(f"Average compute time {avg:.2f} ms exceeded threshold {THRESHOLD_MS} ms")
+        environment.process_exit_code = 1

--- a/tests/perf/run_perf.cmd
+++ b/tests/perf/run_perf.cmd
@@ -1,0 +1,16 @@
+@echo off
+REM run_perf.cmd v0.1.0 (2025-08-20)
+IF "%1"=="--install" (
+    pip install locust
+    GOTO :EOF
+)
+IF "%1"=="--remove" (
+    pip uninstall -y locust
+    GOTO :EOF
+)
+IF "%RUN_TIME%"=="" (
+    set RUN_TIME=1m
+)
+if not exist perf\reports mkdir perf\reports
+locust -f tests\perf\locust_api_gateway.py --headless -u 10 -r 2 -t %RUN_TIME% --csv perf\reports\api_gateway --html perf\reports\api_gateway.html
+locust -f tests\perf\locust_strategy_engine.py --headless -u 10 -r 2 -t %RUN_TIME% --csv perf\reports\strategy_engine --html perf\reports\strategy_engine.html

--- a/tests/perf/run_perf.sh
+++ b/tests/perf/run_perf.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# run_perf.sh v0.1.0 (2025-08-20)
+set -e
+if [ "$1" = "--install" ]; then
+  pip install locust
+  exit 0
+fi
+if [ "$1" = "--remove" ]; then
+  pip uninstall -y locust
+  exit 0
+fi
+RUN_TIME=${RUN_TIME:-1m}
+mkdir -p perf/reports
+locust -f tests/perf/locust_api_gateway.py --headless -u 10 -r 2 -t $RUN_TIME --csv perf/reports/api_gateway --html perf/reports/api_gateway.html
+locust -f tests/perf/locust_strategy_engine.py --headless -u 10 -r 2 -t $RUN_TIME --csv perf/reports/strategy_engine --html perf/reports/strategy_engine.html

--- a/tools/log_create.sh
+++ b/tools/log_create.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# log directory creator v0.6.23 (2025-08-20)
+# log directory creator v0.6.24 (2025-08-20)
 set -e
 mkdir -p logs
 mkdir -p logs/containers
@@ -8,6 +8,7 @@ mkdir -p backtester/reports
 mkdir -p tests/e2e/reports
 mkdir -p ui/.next
 mkdir -p perf
+mkdir -p perf/reports
 mkdir -p execution-engine/logs
 mkdir -p infra/terraform/logs
 mkdir -p logs/notification-service

--- a/tools/log_create_win.cmd
+++ b/tools/log_create_win.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM log directory creator v0.6.23 (2025-08-20)
+REM log directory creator v0.6.24 (2025-08-20)
 mkdir logs 2>nul
 mkdir logs\containers 2>nul
 mkdir logs\analytics 2>nul
@@ -7,6 +7,7 @@ mkdir backtester\reports 2>nul
 mkdir tests\e2e\reports 2>nul
 mkdir ui\.next 2>nul
 mkdir perf 2>nul
+mkdir perf\reports 2>nul
 mkdir execution-engine\logs 2>nul
 mkdir infra\terraform\logs 2>nul
 mkdir logs\notification-service 2>nul

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.47
+# User Manual v0.6.48
 
 Date: 2025-08-20
 
@@ -96,6 +96,9 @@ This document will evolve into a comprehensive encyclopedia for the project.
   - Data Ingestion: `http://localhost:9004/metrics`
   - Backtester: `http://localhost:9005/metrics`
 - Benchmark results are stored under `perf/`.
+- Execute Locust scenarios with `./tests/perf/run_perf.sh` to produce HTML and CSV reports under `perf/reports/`.
+- API Gateway average response time must remain under **500 ms**.
+- Strategy Engine computation time must remain under **100 ms**.
 
 ## Architecture
 - Services communicate via structured logs, metrics, and traces.

--- a/user_manual_2025-08-20.md
+++ b/user_manual_2025-08-20.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.47
+# User Manual v0.6.48
 
 Date: 2025-08-20
 
@@ -96,6 +96,9 @@ This document will evolve into a comprehensive encyclopedia for the project.
   - Data Ingestion: `http://localhost:9004/metrics`
   - Backtester: `http://localhost:9005/metrics`
 - Benchmark results are stored under `perf/`.
+- Execute Locust scenarios with `./tests/perf/run_perf.sh` to produce HTML and CSV reports under `perf/reports/`.
+- API Gateway average response time must remain under **500 ms**.
+- Strategy Engine computation time must remain under **100 ms**.
 
 ## Architecture
 - Services communicate via structured logs, metrics, and traces.


### PR DESCRIPTION
## Summary
- add Locust scenarios for api-gateway and strategy-engine with thresholds and run scripts
- generate perf reports under perf/reports and update log creation scripts
- integrate performance job into CI and document usage in manuals and changelogs

## Testing
- `python -m py_compile tests/perf/locust_api_gateway.py tests/perf/locust_strategy_engine.py`
- `pytest`
- `RUN_TIME=5s API_GATEWAY_URL=https://example.com tests/perf/run_perf.sh` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a53c56b944832c9bb46e5f96114798