### PR TITLE
Add prerequisite checks to Windows installers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.48
+# Changelog v0.6.49
 
 ## 2025-01-14
 - Added Playwright end-to-end tests under `tests/e2e` for UI and API flows.
@@ -203,3 +203,4 @@
 - Wired API gateway onboarding endpoints to proxy uploads and status queries to kyc-service.
 - Expanded log creation scripts, docker-compose, environment samples, requirements and manuals for KYC integration.
 - Added Locust performance tests for api-gateway and strategy-engine with CI integration and reports under `perf/`.
+- Added prerequisite checks for Python, pip, psql, Docker and Node in `setup_full.cmd` and `remove_full.cmd` with documentation in the user manual.

--- a/remove_full.cmd
+++ b/remove_full.cmd
@@ -1,7 +1,35 @@
 @echo off
-rem remove_full.cmd v0.1.1 (2025-08-20)
+rem remove_full.cmd v0.1.2 (2025-08-20)
 
 echo CashMachiine full removal
+
+echo Checking prerequisites...
+where python >nul 2>nul
+if %ERRORLEVEL% neq 0 (
+  echo Python not found. Please install from https://www.python.org/downloads/
+  exit /b 1
+)
+where pip >nul 2>nul
+if %ERRORLEVEL% neq 0 (
+  echo pip not found. Downloading installer...
+  start https://bootstrap.pypa.io/get-pip.py
+  exit /b 1
+)
+where psql >nul 2>nul
+if %ERRORLEVEL% neq 0 (
+  echo PostgreSQL not found. Please install from https://www.postgresql.org/download/
+  exit /b 1
+)
+where docker >nul 2>nul
+if %ERRORLEVEL% neq 0 (
+  echo Docker not found. Please install from https://www.docker.com/get-started/
+  exit /b 1
+)
+where node >nul 2>nul
+if %ERRORLEVEL% neq 0 (
+  echo Node.js not found. Please install from https://nodejs.org/en/download/
+  exit /b 1
+)
 
 echo.
 set /p DB_HOST="Enter database host [localhost]: "

--- a/setup_full.cmd
+++ b/setup_full.cmd
@@ -1,7 +1,35 @@
 @echo off
-rem setup_full.cmd v0.1.0 (2025-08-20)
+rem setup_full.cmd v0.1.1 (2025-08-20)
 
 echo CashMachiine full interactive setup
+
+echo Checking prerequisites...
+where python >nul 2>nul
+if %ERRORLEVEL% neq 0 (
+  echo Python not found. Please install from https://www.python.org/downloads/
+  exit /b 1
+)
+where pip >nul 2>nul
+if %ERRORLEVEL% neq 0 (
+  echo pip not found. Downloading installer...
+  start https://bootstrap.pypa.io/get-pip.py
+  exit /b 1
+)
+where psql >nul 2>nul
+if %ERRORLEVEL% neq 0 (
+  echo PostgreSQL not found. Please install from https://www.postgresql.org/download/
+  exit /b 1
+)
+where docker >nul 2>nul
+if %ERRORLEVEL% neq 0 (
+  echo Docker not found. Please install from https://www.docker.com/get-started/
+  exit /b 1
+)
+where node >nul 2>nul
+if %ERRORLEVEL% neq 0 (
+  echo Node.js not found. Please install from https://nodejs.org/en/download/
+  exit /b 1
+)
 
 echo.
 set /p DB_HOST="Enter database host [localhost]: "

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.48
+# User Manual v0.6.49
 
 Date: 2025-08-20
 
@@ -8,6 +8,13 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Refer to [development_tasks_2025-08-19.md](development_tasks_2025-08-19.md) for the latest task status.
 
 ## Installation
+- Prerequisites:
+  - Python
+  - pip
+  - PostgreSQL `psql`
+  - Docker
+  - Node.js
+- `setup_full.cmd` checks for these tools and opens download pages if any are missing.
 - Copy `.env.example` to `.env` and adjust values as needed, including `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, `RATE_LIMIT_PER_MINUTE`, `ALPHA_VANTAGE_KEY`, `BINANCE_API_KEY`, `BINANCE_API_SECRET` and `IBKR_API_KEY`.
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.


### PR DESCRIPTION
## Summary
- verify presence of Python, pip, psql, Docker and Node in `setup_full.cmd` with installer links
- mirror prerequisite checks in `remove_full.cmd`
- document required tools in user manual and update changelog

## Testing
- `pytest -q` *(interrupted)*
- `npm test` *(missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a5aacd3824832c89c970173cacd643