### PR TITLE
feat: add websocket stream for realtime updates

### DIFF
--- a/api-gateway/__init__.py
+++ b/api-gateway/__init__.py
@@ -1,2 +1,2 @@
-"""api-gateway service v0.3.2 (2025-08-20)"""
-__version__ = "0.3.2"
+"""api-gateway service v0.3.4 (2025-08-20)"""
+__version__ = "0.3.4"

--- a/api-gateway/__init__.py
+++ b/api-gateway/__init__.py
@@ -1,2 +1,2 @@
-"""api-gateway service v0.3.1 (2025-08-20)"""
-__version__ = "0.3.1"
+"""api-gateway service v0.3.2 (2025-08-20)"""
+__version__ = "0.3.2"

--- a/api-gateway/main.py
+++ b/api-gateway/main.py
@@ -1,4 +1,4 @@
-"""FastAPI app exposing goals, actions and analytics endpoints with JWT auth v0.3.3 (2025-08-20)"""
+"""FastAPI app exposing goals, actions and analytics endpoints with JWT auth v0.3.4 (2025-08-20)"""
 from fastapi import (
     FastAPI,
     Depends,
@@ -86,7 +86,7 @@ async def add_version_header(request: Request, call_next):
     with tracer.start_as_current_span(request.url.path):
         response = await call_next(request)
     REQUEST_COUNT.inc()
-    response.headers["X-API-Version"] = "v0.3.3"
+    response.headers["X-API-Version"] = "v0.3.4"
     return response
 
 
@@ -98,8 +98,8 @@ async def dispatch_events():
             try:
                 await ws.send_json(message)
                 alive.append(ws)
-            except Exception:
-                pass
+            except Exception as exc:  # pragma: no cover - log and drop
+                logger.warning("WebSocket send failed", extra={"error": str(exc)})
         ws_clients[:] = alive
 
 

--- a/api-gateway/requirements.txt
+++ b/api-gateway/requirements.txt
@@ -1,4 +1,4 @@
-# requirements.txt v0.1.2 (2025-08-20)
+# requirements.txt v0.1.3 (2025-08-20)
 requests>=2.31.0
 fastapi>=0.110.0
 uvicorn>=0.29.0
@@ -15,3 +15,4 @@ python-dotenv>=1.0.1
 pyotp>=2.9.0
 redis>=5.0.0
 pika>=1.3.2
+websocket-client>=1.8.0

--- a/api-gateway/tests/test_main.py
+++ b/api-gateway/tests/test_main.py
@@ -40,7 +40,7 @@ def test_goals_returns_version_header_and_data():
     token = create_token("user")
     response = client.get("/goals", headers={"Authorization": f"Bearer {token}"})
     assert response.status_code == 200  # nosec
-    assert response.headers["X-API-Version"] == "v0.3.2"  # nosec
+    assert response.headers["X-API-Version"] == "v0.3.3"  # nosec
     assert response.json() == {"goals": []}  # nosec
 
 
@@ -98,6 +98,11 @@ def test_alerts_subscribe():
     resp = client.post("/alerts/subscribe", json={"user_id": 1, "metric": "risk", "threshold": 0.5}, headers={"Authorization": f"Bearer {token}"})
     assert resp.status_code == 200  # nosec
     assert resp.json() == {"status": "subscribed"}  # nosec
+
+
+def test_websocket_endpoint():
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text("ping")
 
 
 def test_onboard_proxy(monkeypatch):

--- a/api-gateway/tests/test_main.py
+++ b/api-gateway/tests/test_main.py
@@ -1,5 +1,5 @@
 # nosec
-"""Unit tests for api-gateway main application v0.3.2 (2025-08-20)"""
+"""Unit tests for api-gateway main application v0.3.4 (2025-08-20)"""
 import os
 
 os.environ["OTEL_SDK_DISABLED"] = "true"
@@ -40,7 +40,7 @@ def test_goals_returns_version_header_and_data():
     token = create_token("user")
     response = client.get("/goals", headers={"Authorization": f"Bearer {token}"})
     assert response.status_code == 200  # nosec
-    assert response.headers["X-API-Version"] == "v0.3.3"  # nosec
+    assert response.headers["X-API-Version"] == "v0.3.4"  # nosec
     assert response.json() == {"goals": []}  # nosec
 
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.59
+# Changelog v0.6.60
 =======
 
 
@@ -231,3 +231,4 @@
 - Added `/ws` WebSocket endpoint in api-gateway streaming action, order and metrics events.
 - UI consumes WebSocket feed to refresh daily actions, goal orders and analytics metrics in real time.
 - Added `websocket-client` dependency and bumped environment setup scripts.
+- Logged WebSocket broadcast errors instead of silently ignoring them to satisfy security scan.

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.58
+# Changelog v0.6.59
 =======
 
 
@@ -228,3 +228,6 @@
 - Created alerts table with migration and schema checks in admin/db_check.php.
 - Exposed /alerts/subscribe in api-gateway and added UI subscription page.
 - Updated log creation scripts for alert-engine outputs.
+- Added `/ws` WebSocket endpoint in api-gateway streaming action, order and metrics events.
+- UI consumes WebSocket feed to refresh daily actions, goal orders and analytics metrics in real time.
+- Added `websocket-client` dependency and bumped environment setup scripts.

--- a/changelog_2025-08-20.md
+++ b/changelog_2025-08-20.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.25
+# Changelog v0.6.26
 
 ## 2025-02-14
 - Introduced user manual revision with installation, usage, architecture and troubleshooting sections.
@@ -123,3 +123,6 @@
 - Created alerts table with migration and schema checks in admin/db_check.php.
 - Exposed /alerts/subscribe in api-gateway and added UI subscription page.
 - Updated log creation scripts for alert-engine outputs.
+- Added `/ws` WebSocket endpoint in api-gateway streaming action, order and metrics events.
+- UI consumes WebSocket feed to refresh daily actions, goal orders and analytics metrics in real time.
+- Added `websocket-client` dependency and bumped environment setup scripts.

--- a/changelog_2025-08-20.md
+++ b/changelog_2025-08-20.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.26
+# Changelog v0.6.27
 
 ## 2025-02-14
 - Introduced user manual revision with installation, usage, architecture and troubleshooting sections.
@@ -126,3 +126,4 @@
 - Added `/ws` WebSocket endpoint in api-gateway streaming action, order and metrics events.
 - UI consumes WebSocket feed to refresh daily actions, goal orders and analytics metrics in real time.
 - Added `websocket-client` dependency and bumped environment setup scripts.
+- Logged WebSocket broadcast errors instead of silently ignoring them to satisfy security scan.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# requirements.txt v0.3.14 (2025-08-20)
+# requirements.txt v0.3.15 (2025-08-20)
 
 # Runtime dependencies
 requests>=2.31.0
@@ -23,6 +23,7 @@ pika>=1.3.2
 scikit-learn>=1.4.2
 web3>=6.0.0
 sqlalchemy>=2.0.29
+websocket-client>=1.8.0
 
 # Development dependencies
 pytest>=8.2.0

--- a/setup_env.cmd
+++ b/setup_env.cmd
@@ -1,5 +1,5 @@
 @echo off
-rem setup_env.cmd v0.2.2 (2025-08-20)
+rem setup_env.cmd v0.2.3 (2025-08-20)
 
 pip install -r "%~dp0requirements.txt"
 

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# setup_env.sh v0.2.2 (2025-08-20)
+# setup_env.sh v0.2.3 (2025-08-20)
 
 set -e
 

--- a/setup_full.cmd
+++ b/setup_full.cmd
@@ -1,5 +1,5 @@
 @echo off
-rem setup_full.cmd v0.1.1 (2025-08-20)
+rem setup_full.cmd v0.1.2 (2025-08-20)
 
 echo CashMachiine full interactive setup
 

--- a/ui/lib/useEventStream.js
+++ b/ui/lib/useEventStream.js
@@ -1,0 +1,19 @@
+/** WebSocket event hook v0.1.0 (2025-08-20) */
+import { useEffect, useState } from 'react';
+
+export function useEventStream() {
+  const [event, setEvent] = useState(null);
+  useEffect(() => {
+    const base = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+    const ws = new WebSocket(base.replace('http', 'ws') + '/ws');
+    ws.onmessage = e => {
+      try {
+        setEvent(JSON.parse(e.data));
+      } catch {
+        // ignore invalid JSON
+      }
+    };
+    return () => ws.close();
+  }, []);
+  return event;
+}

--- a/ui/pages/analytics.js
+++ b/ui/pages/analytics.js
@@ -1,6 +1,7 @@
-/** Analytics dashboard page v0.2.0 (2025-08-19) */
+/** Analytics dashboard page v0.2.1 (2025-08-20) */
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from '../lib/useTranslation';
+import { useEventStream } from '../lib/useEventStream';
 import { Chart } from 'chart.js/auto';
 
 export default function Analytics() {
@@ -8,6 +9,7 @@ export default function Analytics() {
   const base = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
   const [data, setData] = useState(null);
   const canvasRef = useRef(null);
+  const event = useEventStream();
 
   useEffect(() => {
     fetch(`${base}/analytics`)
@@ -33,6 +35,12 @@ export default function Analytics() {
       return () => chart.destroy();
     }
   }, [data, t]);
+
+  useEffect(() => {
+    if (event && event.event === 'metrics') {
+      setData(d => ({ ...(d || {}), metrics: event.payload }));
+    }
+  }, [event]);
 
   if (!data) {
     return <div className="p-4">{t('analytics.loading')}</div>;

--- a/ui/pages/daily-actions.js
+++ b/ui/pages/daily-actions.js
@@ -1,12 +1,14 @@
-/** Daily actions page v0.3.1 (2025-08-20) */
+/** Daily actions page v0.3.2 (2025-08-20) */
 import { useEffect, useState } from 'react';
 import { useTranslation } from '../lib/useTranslation';
+import { useEventStream } from '../lib/useEventStream';
 
 export default function DailyActions() {
   const t = useTranslation();
   const base = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
   const [actions, setActions] = useState([]);
   const [message, setMessage] = useState('');
+  const event = useEventStream();
 
   useEffect(() => {
     const cached = localStorage.getItem('actions');
@@ -19,6 +21,16 @@ export default function DailyActions() {
       })
       .catch(() => {});
   }, [base]);
+
+  useEffect(() => {
+    if (event && event.event === 'action') {
+      setActions(as => {
+        const updated = [...as, event.payload];
+        localStorage.setItem('actions', JSON.stringify(updated));
+        return updated;
+      });
+    }
+  }, [event]);
 
   const check = id => {
     fetch(`${base}/actions/${id}/check`, { method: 'POST' })

--- a/ui/pages/goals.js
+++ b/ui/pages/goals.js
@@ -1,11 +1,14 @@
-/** Goal creation page v0.2.1 (2025-08-20) */
-import { useState } from 'react';
+/** Goal creation page v0.2.2 (2025-08-20) */
+import { useEffect, useState } from 'react';
 import { useTranslation } from '../lib/useTranslation';
+import { useEventStream } from '../lib/useEventStream';
 
 export default function Goals() {
   const t = useTranslation();
   const [name, setName] = useState('');
   const [message, setMessage] = useState('');
+  const [orders, setOrders] = useState([]);
+  const event = useEventStream();
 
   const submitGoal = async (e) => {
     e.preventDefault();
@@ -16,6 +19,12 @@ export default function Goals() {
     });
     setMessage(res.ok ? t('goals.success') : t('goals.error'));
   };
+
+  useEffect(() => {
+    if (event && event.event === 'order') {
+      setOrders(os => [...os, event.payload]);
+    }
+  }, [event]);
 
   return (
     <div className="p-4">
@@ -30,6 +39,13 @@ export default function Goals() {
         <button className="bg-blue-500 text-white px-4 py-2" type="submit">{t('goals.submit')}</button>
       </form>
       {message && <p className="mt-4">{message}</p>}
+      {orders.length > 0 && (
+        <ul className="mt-4 list-disc ml-5">
+          {orders.map((o, i) => (
+            <li key={i}>{o.description || o.id || JSON.stringify(o)}</li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.60
+# User Manual v0.6.61
 =======
 
 
@@ -88,6 +88,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Mark tasks complete on the daily actions page; checkboxes send POST requests to `/actions/{id}/check` and show feedback messages.
 - The daily actions checklist also allows exporting orders for external processing.
 - Visualize aggregated metrics via the `/analytics` endpoint or the UI analytics page, which renders charts with Chart.js.
+- A `/ws` WebSocket endpoint streams `action`, `order` and `metrics` events; the UI consumes this feed to update pages in real time.
 - The feasibility-calculator service exposes `/feasibility` to estimate CAGR, daily returns and probability of hitting a target based on capital, goal, deadline and risk profile.
 - The whatif-service provides `/scenarios/run` and `/scenarios/{id}` endpoints to run scenarios and retrieve stored results in the `scenario_results` table.
 - It now binds to `127.0.0.1` by default for improved security.

--- a/user_manual_2025-08-20.md
+++ b/user_manual_2025-08-20.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.60
+# User Manual v0.6.61
 
 Date: 2025-08-20
 
@@ -79,6 +79,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Mark tasks complete on the daily actions page; checkboxes send POST requests to `/actions/{id}/check` and show feedback messages.
 - The daily actions checklist also allows exporting orders for external processing.
 - Visualize aggregated metrics via the `/analytics` endpoint or the UI analytics page, which renders charts with Chart.js.
+- A `/ws` WebSocket endpoint streams `action`, `order` and `metrics` events; the UI consumes this feed to update pages in real time.
 - The feasibility-calculator service exposes `/feasibility` to estimate CAGR, daily returns and probability of hitting a target based on capital, goal, deadline and risk profile.
 - The whatif-service provides `/scenarios/run` and `/scenarios/{id}` endpoints to run scenarios and retrieve stored results in the `scenario_results` table.
 - It now binds to `127.0.0.1` by default for improved security.


### PR DESCRIPTION
## Summary
- add websocket endpoint in api-gateway to stream actions, orders, and metrics
- consume websocket feed in UI for realtime analytics, actions, and orders
- document usage and add websocket-client dependency

## Testing
- `pytest api-gateway/tests`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a61f138ce8832cb6229434e0e29733