### PR TITLE
feat: detect risk anomalies and alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Goal-Based Investment Copilot — Spécification fonctionnelle v0.1.7
+# Goal-Based Investment Copilot — Spécification fonctionnelle v0.1.8
 
 [![Lint](https://github.com/OpenAI/CashMachiine/actions/workflows/ci.yml/badge.svg?branch=main&job=lint)](https://github.com/OpenAI/CashMachiine/actions/workflows/ci.yml?query=branch%3Amain)
 [![Tests](https://github.com/OpenAI/CashMachiine/actions/workflows/ci.yml/badge.svg?branch=main&job=test)](https://github.com/OpenAI/CashMachiine/actions/workflows/ci.yml?query=branch%3Amain)
@@ -82,7 +82,7 @@ Voir aussi la section [Architecture](user_manual_2025-08-19.md#architecture) du 
 * `orchestrator` — planifie la routine quotidienne (08:00 Europe/Paris) + jobs intraday.
 * `data-ingestion` — connecteurs de marché (pull/stream), normalisation OHLCV.
 * `strategy-engine` — signaux, allocations cibles, simulation Monte-Carlo.
-* `risk-engine` — budget de risque, limites (VaR/ES), SL/TP, levier.
+* `risk-engine` — budget de risque, limites (VaR/ES), SL/TP, levier, détection d'anomalies.
 * `execution-engine` — génération d’ordres, agrégation par broker, contrôle post-trade.
 * `backtester` — backtests/forward-tests reproductibles, rapports.
 * `ui` (Next.js/React + Tailwind) — Dashboard, Analytics, Wizard d’objectifs, Daily Actionables, Historique, What‑if.

--- a/admin/db_check.php
+++ b/admin/db_check.php
@@ -1,6 +1,6 @@
 <?php
-// db_check.php v0.1.16 (2025-08-20)
-$expectedVersion = 'v0.1.13';
+// db_check.php v0.1.17 (2025-08-20)
+$expectedVersion = 'v0.1.14';
 $dsn = sprintf('pgsql:host=%s;port=%s;dbname=%s',
     getenv('DB_HOST') ?: 'localhost',
     getenv('DB_PORT') ?: '5432',
@@ -9,7 +9,7 @@ $user = getenv('DB_USER') ?: 'postgres';
 $pass = getenv('DB_PASS') ?: '';
 $requiredTables = [
     'users','goals','accounts','portfolios','positions','orders',
-    'executions','prices','signals','actions','risk_limits','metrics_daily',
+    'executions','prices','signals','actions','risk_limits','metrics_daily','risk_anomalies',
     'backtests','risk_stress_results','notifications','alerts','strategies','strategy_reviews','audit_events','scenario_results'
 ];
 $warehouseTables = ['dw_orders','dw_positions'];
@@ -133,6 +133,15 @@ $cols = $stmt->fetchAll(PDO::FETCH_COLUMN);
   foreach ($alertColumns as $col) {
       if (!in_array($col, $cols)) {
           echo "Missing column in alerts: $col\n";
+          exit(1);
+      }
+  }
+  $anomalyColumns = ['id','date','portfolio_id','metric','value','score','created_at'];
+  $stmt = $pdo->query("SELECT column_name FROM information_schema.columns WHERE table_name='risk_anomalies'");
+  $cols = $stmt->fetchAll(PDO::FETCH_COLUMN);
+  foreach ($anomalyColumns as $col) {
+      if (!in_array($col, $cols)) {
+          echo "Missing column in risk_anomalies: $col\n";
           exit(1);
       }
   }

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.61
+# Changelog v0.6.62
 =======
 
 
@@ -233,3 +233,4 @@
 - Added `websocket-client` dependency and bumped environment setup scripts.
 - Logged WebSocket broadcast errors instead of silently ignoring them to satisfy security scan.
 - Added containerized strategy execution with signature verification, resource quotas and dedicated execution logs.
+- Introduced IsolationForest-based anomaly detection on `metrics_daily`, storing results in `risk_anomalies` and emitting alerts via `alert-engine`.

--- a/db/migrations/027_create_risk_anomalies.sql
+++ b/db/migrations/027_create_risk_anomalies.sql
@@ -1,0 +1,10 @@
+-- risk_anomalies table migration v0.1.0 (2025-08-20)
+CREATE TABLE IF NOT EXISTS risk_anomalies (
+    id SERIAL PRIMARY KEY,
+    date DATE NOT NULL,
+    portfolio_id INTEGER REFERENCES portfolios(id),
+    metric TEXT NOT NULL,
+    value NUMERIC NOT NULL,
+    score NUMERIC,
+    created_at TIMESTAMP DEFAULT NOW()
+);

--- a/remove_db.sh
+++ b/remove_db.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# remove_db.sh v0.1.1 (2025-08-20)
+# remove_db.sh v0.1.2 (2025-08-20)
 set -e
-TABLES=(actions backtests metrics_daily risk_limits signals prices executions orders positions portfolios accounts goals users audit_events)
+TABLES=(actions backtests metrics_daily risk_anomalies risk_limits signals prices executions orders positions portfolios accounts goals users audit_events)
 for tbl in "${TABLES[@]}"; do
   echo "Dropping $tbl"
   psql "$@" -c "DROP TABLE IF EXISTS $tbl CASCADE;"

--- a/remove_full.cmd
+++ b/remove_full.cmd
@@ -1,5 +1,5 @@
 @echo off
-rem remove_full.cmd v0.1.2 (2025-08-20)
+rem remove_full.cmd v0.1.3 (2025-08-20)
 
 echo CashMachiine full removal
 
@@ -44,7 +44,7 @@ set /p DB_PASS="Enter database password: "
 
 echo Dropping tables...
 set PGPASSWORD=%DB_PASS%
-for %%T in (actions backtests metrics_daily risk_limits signals prices executions orders positions portfolios accounts goals users audit_events) do (
+for %%T in (actions backtests metrics_daily risk_anomalies risk_limits signals prices executions orders positions portfolios accounts goals users audit_events) do (
   echo Dropping %%T
   psql -h %DB_HOST% -p %DB_PORT% -U %DB_USER% -d %DB_NAME% -c "DROP TABLE IF EXISTS %%T CASCADE;"
 )

--- a/risk-engine/__init__.py
+++ b/risk-engine/__init__.py
@@ -1,4 +1,3 @@
-"""risk-engine service v0.4.5 (2025-08-19)"""
-__version__ = "0.4.5"
+"""risk-engine service v0.4.6 (2025-08-20)"""
+__version__ = "0.4.6"
 
-from .engine import volatility_target, var_es, kelly_fraction

--- a/risk-engine/anomaly.py
+++ b/risk-engine/anomaly.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Risk metric anomaly detection v0.1.0 (2025-08-20)"""
+
+import os
+from typing import List, Tuple
+
+import pandas as pd
+import psycopg2
+from sklearn.ensemble import IsolationForest
+
+from common.monitoring import setup_logging
+from config import settings
+from messaging import EventProducer
+
+LOG_PATH = os.path.join("logs", "risk-engine", "anomaly.log")
+os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
+logger = setup_logging("risk-engine", log_path=LOG_PATH, remote_url=settings.remote_log_url)
+
+FEATURES = ["nav", "ret", "vol", "dd", "var95", "es97"]
+
+
+def _fetch_metrics() -> pd.DataFrame:
+    with psycopg2.connect(
+        host=settings.db_host,
+        port=settings.db_port,
+        dbname=settings.db_name,
+        user=settings.db_user,
+        password=settings.db_pass,
+    ) as conn:
+        return pd.read_sql_query(
+            "SELECT date, portfolio_id, nav, ret, vol, dd, var95, es97 FROM metrics_daily",
+            conn,
+        )
+
+
+def _store_anomalies(rows: List[Tuple]) -> None:
+    if not rows:
+        return
+    with psycopg2.connect(
+        host=settings.db_host,
+        port=settings.db_port,
+        dbname=settings.db_name,
+        user=settings.db_user,
+        password=settings.db_pass,
+    ) as conn:
+        with conn.cursor() as cur:
+            cur.executemany(
+                "INSERT INTO risk_anomalies (date, portfolio_id, metric, value, score) VALUES (%s,%s,%s,%s,%s)",
+                rows,
+            )
+
+
+def detect_anomalies() -> None:
+    df = _fetch_metrics()
+    if df.empty:
+        logger.info("No metrics available for anomaly detection")
+        return
+    producer = EventProducer(settings.rabbitmq_url)
+    anomalies: List[Tuple] = []
+    try:
+        for metric in FEATURES:
+            model = IsolationForest(contamination=0.05, random_state=42)
+            values = df[[metric]].values
+            if len(values) < 10:
+                continue
+            model.fit(values)
+            preds = model.predict(values)
+            scores = model.decision_function(values)
+            for row, pred, score in zip(df.itertuples(index=False), preds, scores):
+                if pred == -1:
+                    anomalies.append(
+                        (row.date, row.portfolio_id, metric, getattr(row, metric), float(score))
+                    )
+                    producer.publish(
+                        "risk_metric", {"metric": f"{metric}_anomaly", "value": 1.0}
+                    )
+                    logger.warning(
+                        "Anomaly detected",
+                        extra={
+                            "date": str(row.date),
+                            "portfolio_id": row.portfolio_id,
+                            "metric": metric,
+                            "value": getattr(row, metric),
+                            "score": float(score),
+                        },
+                    )
+    finally:
+        producer.close()
+    _store_anomalies(anomalies)
+
+
+if __name__ == "__main__":
+    detect_anomalies()

--- a/risk-engine/install.sh
+++ b/risk-engine/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# risk-engine installer v0.4.5 (2025-08-19)
+# risk-engine installer v0.4.6 (2025-08-20)
 set -e
 
 echo "Installing risk-engine service..."

--- a/risk-engine/main.py
+++ b/risk-engine/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""risk-engine service v0.4.5 (2025-08-19)"""
+"""risk-engine service v0.4.6 (2025-08-20)"""
 
 import argparse
 import json
@@ -17,7 +17,7 @@ from messaging import EventConsumer
 from engine import volatility_target
 from stress_tests import historical_scenario, hypothetical_scenario
 
-app = FastAPI(title="risk-engine", version="0.3.1")
+app = FastAPI(title="risk-engine", version="0.3.2")
 logger = setup_logging("risk-engine", remote_url=settings.remote_log_url)
 REQUEST_COUNT = setup_metrics("risk-engine", port=settings.risk_engine_metrics_port)
 tracer = setup_tracer("risk-engine")
@@ -28,7 +28,7 @@ async def add_version_header(request: Request, call_next):
     with tracer.start_as_current_span(request.url.path):
         response = await call_next(request)
     REQUEST_COUNT.inc()
-    response.headers["X-API-Version"] = "v0.3.1"
+    response.headers["X-API-Version"] = "v0.3.2"
     return response
 
 
@@ -90,7 +90,7 @@ def handle_event(message: dict) -> None:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="risk-engine consumer v0.4.5")
+    parser = argparse.ArgumentParser(description="risk-engine consumer v0.4.6")
     parser.add_argument("--install", action="store_true", help="Install risk-engine service")
     parser.add_argument("--remove", action="store_true", help="Remove risk-engine service")
     parser.add_argument(

--- a/risk-engine/remove.sh
+++ b/risk-engine/remove.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# risk-engine removal v0.4.5 (2025-08-19)
+# risk-engine removal v0.4.6 (2025-08-20)
 set -e
 
 echo "Removing risk-engine service..."

--- a/risk-engine/requirements.txt
+++ b/risk-engine/requirements.txt
@@ -1,4 +1,4 @@
-# requirements.txt v0.1.1 (2025-08-19)
+# requirements.txt v0.1.2 (2025-08-20)
 requests>=2.31.0
 fastapi>=0.110.0
 uvicorn>=0.29.0
@@ -15,3 +15,4 @@ opentelemetry-sdk>=1.24.0
 python-dotenv>=1.0.1
 redis>=5.0.0
 pika>=1.3.2
+scikit-learn>=1.4.2

--- a/risk-engine/tests/test_anomaly.py
+++ b/risk-engine/tests/test_anomaly.py
@@ -1,0 +1,57 @@
+"""Tests for anomaly detection v0.1.0 (2025-08-20)"""
+import importlib.util
+import sys
+from pathlib import Path
+import pandas as pd
+
+__version__ = "0.1.0"
+
+ANOM_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ANOM_DIR.parent))
+
+
+def load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+anomaly = load("risk_engine.anomaly", ANOM_DIR / "anomaly.py")
+
+
+class DummyConn:
+    def __enter__(self):
+        return self
+    def __exit__(self, *args):
+        pass
+    def cursor(self):
+        class Cur:
+            def executemany(self, *args, **kwargs):
+                pass
+            def __enter__(self):
+                return self
+            def __exit__(self, *args):
+                pass
+        return Cur()
+
+
+def test_detect_anomalies_no_data(monkeypatch):
+    monkeypatch.setattr(anomaly.psycopg2, "connect", lambda *a, **k: DummyConn())
+    monkeypatch.setattr(
+        anomaly.pd,
+        "read_sql_query",
+        lambda *a, **k: pd.DataFrame(
+            columns=["date", "portfolio_id", "nav", "ret", "vol", "dd", "var95", "es97"]
+        ),
+    )
+    class DummyProducer:
+        def __init__(self, url):
+            self.published = []
+        def publish(self, event, payload):
+            self.published.append((event, payload))
+        def close(self):
+            pass
+    monkeypatch.setattr(anomaly, "EventProducer", DummyProducer)
+    anomaly.detect_anomalies()

--- a/tools/log_create.sh
+++ b/tools/log_create.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# log directory creator v0.6.29 (2025-08-20)
+# log directory creator v0.6.30 (2025-08-20)
 set -e
 mkdir -p logs
 mkdir -p logs/containers
@@ -19,6 +19,7 @@ mkdir -p logs/ui
 mkdir -p logs/data-warehouse
 mkdir -p logs/kyc-service
 mkdir -p logs/alert-engine
+mkdir -p logs/risk-engine
 mkdir -p kyc-service/uploads
 mkdir -p strategy-engine/models
 mkdir -p strategy-marketplace/assets
@@ -30,6 +31,7 @@ touch logs/orchestrator.log
 touch logs/data-ingestion.log
 touch logs/strategy-engine.log
 touch logs/risk-engine.log
+touch logs/risk-engine/anomaly.log
 touch logs/execution-engine.log
 touch logs/messaging.log
 touch logs/feasibility-calculator.log

--- a/tools/log_create_win.cmd
+++ b/tools/log_create_win.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM log directory creator v0.6.29 (2025-08-20)
+REM log directory creator v0.6.30 (2025-08-20)
 mkdir logs 2>nul
 mkdir logs\containers 2>nul
 mkdir logs\analytics 2>nul
@@ -18,6 +18,7 @@ mkdir logs\ui 2>nul
 mkdir logs\data-warehouse 2>nul
 mkdir logs\kyc-service 2>nul
 mkdir logs\alert-engine 2>nul
+mkdir logs\risk-engine 2>nul
 mkdir kyc-service\uploads 2>nul
 mkdir strategy-engine\models 2>nul
 mkdir strategy-marketplace\assets 2>nul
@@ -29,6 +30,7 @@ type nul > logs\orchestrator.log
 type nul > logs\data-ingestion.log
 type nul > logs\strategy-engine.log
 type nul > logs\risk-engine.log
+type nul > logs\risk-engine\anomaly.log
 type nul > logs\execution-engine.log
 type nul > logs\messaging.log
 type nul > logs\feasibility-calculator.log

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.62
+# User Manual v0.6.63
 =======
 
 
@@ -139,6 +139,9 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Tests use `# nosec` to bypass false positives and subprocess calls are validated.
 - The UI now runs on Next.js 14.2.32 following security advisories.
 
+## Risk Anomaly Detection
+- `risk-engine/anomaly.py` analyse `metrics_daily` via IsolationForest pour détecter des valeurs extrêmes.
+- Les anomalies sont enregistrées dans la table `risk_anomalies` puis un événement `risk_metric` déclenche une alerte via `alert-engine`.
 ## fx-service
 - Provides currency conversions using European Central Bank rates.
 - POST `/convert` with JSON `{ "from_currency": "USD", "to_currency": "EUR", "amount": 1.23 }`.


### PR DESCRIPTION
## Summary
- add IsolationForest anomaly detection for daily metrics
- store anomalies in risk_anomalies table and alert via alert-engine
- document anomaly workflow and update log scripts

## Testing
- `pytest risk-engine/tests`
- `php -l admin/db_check.php`


------
https://chatgpt.com/codex/tasks/task_e_68a62b17e3bc832c8e83bbfd256aacbc