### PR TITLE
feat: add virtualenv to windows setup

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.65
+# Changelog v0.6.66
 =======
 
 
@@ -242,3 +242,6 @@
 - Added containerized strategy execution with signature verification, resource quotas and dedicated execution logs.
 - Introduced reporting utility using WeasyPrint to generate PDF summaries of actions, orders, KYC and metrics under `reports/` with install/remove options and updated log scripts, requirements and manuals.
 - Reviewed development tasks, marked completed feasibility integration, added WebSocket reconnection and alert-engine documentation tasks, and updated user manual references.
+- setup_full.cmd now creates and activates a Python virtual environment before installing dependencies.
+- remove_full.cmd now removes the virtual environment during teardown.
+- Documented virtual environment usage in user manuals and bumped script versions.

--- a/remove_full.cmd
+++ b/remove_full.cmd
@@ -1,5 +1,5 @@
 @echo off
-rem remove_full.cmd v0.1.2 (2025-08-20)
+rem remove_full.cmd v0.1.3 (2025-08-20)
 
 echo CashMachiine full removal
 
@@ -50,8 +50,17 @@ for %%T in (actions backtests metrics_daily risk_limits signals prices execution
 )
 set PGPASSWORD=
 
-echo Uninstalling Python dependencies...
-pip uninstall -r "%~dp0requirements.txt" -y
+echo Removing Python environment...
+if exist venv (
+  call venv\Scripts\activate
+  echo Uninstalling Python dependencies...
+  pip uninstall -r "%~dp0requirements.txt" -y
+  deactivate
+  rmdir /s /q venv
+) else (
+  echo venv not found. Attempting global uninstall.
+  pip uninstall -r "%~dp0requirements.txt" -y
+)
 
 where docker >nul 2>nul
 if %ERRORLEVEL%==0 (

--- a/setup_full.cmd
+++ b/setup_full.cmd
@@ -1,5 +1,5 @@
 @echo off
-rem setup_full.cmd v0.1.2 (2025-08-20)
+rem setup_full.cmd v0.1.3 (2025-08-20)
 
 echo CashMachiine full interactive setup
 
@@ -41,6 +41,12 @@ if "%DB_NAME%"=="" set DB_NAME=cashmachiine
 set /p DB_USER="Enter database user [postgres]: "
 if "%DB_USER%"=="" set DB_USER=postgres
 set /p DB_PASS="Enter database password: "
+
+echo Creating Python virtual environment...
+if not exist venv (
+  python -m venv venv
+)
+call venv\Scripts\activate
 
 echo Installing Python dependencies...
 pip install -r "%~dp0requirements.txt"

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.66
+# User Manual v0.6.67
 =======
 
 
@@ -22,7 +22,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Set `KYC_HOST` to control the bind address of the KYC service (defaults to `127.0.0.1`).
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
-- Run `setup_full.cmd` for an interactive Windows setup including database creation; use `remove_full.cmd` to uninstall and drop tables.
+- Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; use `remove_full.cmd` to uninstall, remove the environment, and drop tables.
 - Each service provides `install.sh` and `remove.sh` scripts.
 - Each service now ships with its own `requirements.txt` for Docker builds.
 - Requirements now include `web3` for on-chain interactions.

--- a/user_manual_2025-08-20.md
+++ b/user_manual_2025-08-20.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.66
+# User Manual v0.6.67
 
 Date: 2025-08-20
 
@@ -13,7 +13,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Set `KYC_HOST` to control the bind address of the KYC service (defaults to `127.0.0.1`).
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
-- Run `setup_full.cmd` for an interactive Windows setup including database creation; use `remove_full.cmd` to uninstall and drop tables.
+- Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; use `remove_full.cmd` to uninstall, remove the environment, and drop tables.
 - Each service provides `install.sh` and `remove.sh` scripts.
 - Each service now ships with its own `requirements.txt` for Docker builds.
 - Requirements now include `web3` for on-chain interactions.


### PR DESCRIPTION
## Summary
- create and activate a Python virtual environment in `setup_full.cmd`
- tear down the virtual environment via `remove_full.cmd`
- document virtualenv usage and bump versions

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a63b274c4c832cb88123a6ec8214ad