### PR TITLE
Add service configuration prompts to Windows setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# .env.example v0.1.8 (2025-08-20)
+# .env.example v0.1.9 (2025-08-20)
 SECRET_KEY=change_me
 REMOTE_LOG_URL=
 API_GATEWAY_METRICS_PORT=9001
@@ -9,6 +9,7 @@ DB_NAME=cashmachiine
 DB_USER=postgres
 DB_PASS=
 RISK_ENGINE_URL=http://localhost:8000
+API_GATEWAY_URL=http://localhost:8000
 REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_DB=0

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.66
+# Changelog v0.6.67
 =======
 
 
@@ -245,3 +245,4 @@
 - setup_full.cmd now creates and activates a Python virtual environment before installing dependencies.
 - remove_full.cmd now removes the virtual environment during teardown.
 - Documented virtual environment usage in user manuals and bumped script versions.
+- Added interactive prompts for RabbitMQ, API Gateway and API keys in setup_full.cmd with .env updates; remove_full.cmd now purges these credentials.

--- a/remove_full.cmd
+++ b/remove_full.cmd
@@ -1,5 +1,5 @@
 @echo off
-rem remove_full.cmd v0.1.3 (2025-08-20)
+rem remove_full.cmd v0.1.4 (2025-08-20)
 
 echo CashMachiine full removal
 
@@ -67,6 +67,12 @@ if %ERRORLEVEL%==0 (
   docker compose down 2>nul || docker-compose down
 ) else (
   echo Docker not found, skipping container stop.
+)
+
+if exist .env (
+  echo Clearing service credentials from .env...
+  powershell -Command ^
+    "$envpath='.env'; $vars = 'RABBITMQ_URL','API_GATEWAY_URL','ALPHA_VANTAGE_KEY','BINANCE_API_KEY','BINANCE_API_SECRET','IBKR_API_KEY','FRED_API_KEY'; $content = Get-Content $envpath; foreach($k in $vars){$pattern = '^' + [regex]::Escape($k) + '='; if($content -match $pattern){$content = $content -replace $pattern + '.*', $k + '='}}; Set-Content $envpath $content"
 )
 
 echo Removal complete.

--- a/setup_full.cmd
+++ b/setup_full.cmd
@@ -1,5 +1,5 @@
 @echo off
-rem setup_full.cmd v0.1.3 (2025-08-20)
+rem setup_full.cmd v0.1.4 (2025-08-20)
 
 echo CashMachiine full interactive setup
 
@@ -41,6 +41,20 @@ if "%DB_NAME%"=="" set DB_NAME=cashmachiine
 set /p DB_USER="Enter database user [postgres]: "
 if "%DB_USER%"=="" set DB_USER=postgres
 set /p DB_PASS="Enter database password: "
+set /p RABBITMQ_URL="Enter RabbitMQ URL [amqp://guest:guest@localhost:5672/]: "
+if "%RABBITMQ_URL%"=="" set RABBITMQ_URL=amqp://guest:guest@localhost:5672/
+set /p API_GATEWAY_URL="Enter API Gateway URL [http://localhost:8000]: "
+if "%API_GATEWAY_URL%"=="" set API_GATEWAY_URL=http://localhost:8000
+set /p ALPHA_VANTAGE_KEY="Enter Alpha Vantage API key [demo]: "
+if "%ALPHA_VANTAGE_KEY%"=="" set ALPHA_VANTAGE_KEY=demo
+set /p BINANCE_API_KEY="Enter Binance API key [demo]: "
+if "%BINANCE_API_KEY%"=="" set BINANCE_API_KEY=demo
+set /p BINANCE_API_SECRET="Enter Binance API secret [demo]: "
+if "%BINANCE_API_SECRET%"=="" set BINANCE_API_SECRET=demo
+set /p IBKR_API_KEY="Enter IBKR API key [demo]: "
+if "%IBKR_API_KEY%"=="" set IBKR_API_KEY=demo
+set /p FRED_API_KEY="Enter FRED API key [demo]: "
+if "%FRED_API_KEY%"=="" set FRED_API_KEY=demo
 
 echo Creating Python virtual environment...
 if not exist venv (
@@ -55,6 +69,15 @@ if not exist .env (
   echo Creating .env from sample...
   copy .env.example .env >nul
 )
+
+echo Updating .env with provided values...
+powershell -Command ^
+  "$envpath='.env';" ^
+  "$vars = @{'DB_HOST'='%DB_HOST%'; 'DB_PORT'='%DB_PORT%'; 'DB_NAME'='%DB_NAME%'; 'DB_USER'='%DB_USER%'; 'DB_PASS'='%DB_PASS%'; 'RABBITMQ_URL'='%RABBITMQ_URL%'; 'API_GATEWAY_URL'='%API_GATEWAY_URL%'; 'ALPHA_VANTAGE_KEY'='%ALPHA_VANTAGE_KEY%'; 'BINANCE_API_KEY'='%BINANCE_API_KEY%'; 'BINANCE_API_SECRET'='%BINANCE_API_SECRET%'; 'IBKR_API_KEY'='%IBKR_API_KEY%'; 'FRED_API_KEY'='%FRED_API_KEY%'};" ^
+  "if(!(Test-Path $envpath)){New-Item $envpath -ItemType File | Out-Null};" ^
+  "$content = Get-Content $envpath;" ^
+  "foreach($k in $vars.Keys){$pattern = '^' + [regex]::Escape($k) + '='; $replacement = \"$k=$($vars[$k])\"; if($content -match $pattern){$content = $content -replace $pattern + '.*', $replacement} else {$content += $replacement}};" ^
+  "Set-Content $envpath $content"
 
 echo Creating and migrating database...
 set PGPASSWORD=%DB_PASS%

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.67
+# User Manual v0.6.68
 =======
 
 
@@ -16,13 +16,13 @@ This document will evolve into a comprehensive encyclopedia for the project.
   - PostgreSQL `psql`
   - Docker
   - Node.js
-- `setup_full.cmd` checks for these tools and opens download pages if any are missing.
+- `setup_full.cmd` checks for these tools, prompts for database, RabbitMQ, API Gateway and API keys, writing values to `.env`, and opens download pages if any are missing.
 - Copy `.env.example` to `.env` and adjust values as needed, including `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, `RATE_LIMIT_PER_MINUTE`, `ALPHA_VANTAGE_KEY`, `BINANCE_API_KEY`, `BINANCE_API_SECRET`, `IBKR_API_KEY` and `FRED_API_KEY`.
 - Configure OAuth token endpoints via `GOOGLE_TOKEN_URL` and `GITHUB_TOKEN_URL` if overriding defaults.
 - Set `KYC_HOST` to control the bind address of the KYC service (defaults to `127.0.0.1`).
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
-- Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; use `remove_full.cmd` to uninstall, remove the environment, and drop tables.
+- Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; it now records service URLs and API keys in `.env`. Use `remove_full.cmd` to uninstall, remove the environment, drop tables, and purge these credentials.
 - Each service provides `install.sh` and `remove.sh` scripts.
 - Each service now ships with its own `requirements.txt` for Docker builds.
 - Requirements now include `web3` for on-chain interactions.


### PR DESCRIPTION
## Summary
- prompt for RabbitMQ, API gateway and API key settings in `setup_full.cmd`
- persist configuration values to `.env` and clear them in `remove_full.cmd`
- document interactive service configuration in manuals and changelog

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a63d427cb0832c83e3536f3f2d5508