### PR TITLE
chore: invoke log creation in Windows installers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.67
+# Changelog v0.6.68
 =======
 
 
@@ -246,3 +246,4 @@
 - remove_full.cmd now removes the virtual environment during teardown.
 - Documented virtual environment usage in user manuals and bumped script versions.
 - Added interactive prompts for RabbitMQ, API Gateway and API keys in setup_full.cmd with .env updates; remove_full.cmd now purges these credentials.
+- setup_env.cmd and setup_full.cmd now invoke `tools\\log_create_win.cmd` at startup to create log directories.

--- a/setup_env.cmd
+++ b/setup_env.cmd
@@ -1,5 +1,7 @@
 @echo off
-rem setup_env.cmd v0.2.3 (2025-08-20)
+rem setup_env.cmd v0.2.4 (2025-08-20)
+
+call tools\log_create_win.cmd
 
 pip install -r "%~dp0requirements.txt"
 

--- a/setup_full.cmd
+++ b/setup_full.cmd
@@ -1,5 +1,7 @@
 @echo off
-rem setup_full.cmd v0.1.4 (2025-08-20)
+rem setup_full.cmd v0.1.5 (2025-08-20)
+
+call tools\log_create_win.cmd
 
 echo CashMachiine full interactive setup
 

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.68
+# User Manual v0.6.69
 =======
 
 
@@ -20,9 +20,9 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Copy `.env.example` to `.env` and adjust values as needed, including `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, `RATE_LIMIT_PER_MINUTE`, `ALPHA_VANTAGE_KEY`, `BINANCE_API_KEY`, `BINANCE_API_SECRET`, `IBKR_API_KEY` and `FRED_API_KEY`.
 - Configure OAuth token endpoints via `GOOGLE_TOKEN_URL` and `GITHUB_TOKEN_URL` if overriding defaults.
 - Set `KYC_HOST` to control the bind address of the KYC service (defaults to `127.0.0.1`).
-- Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies.
+- Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies; the Windows script now invokes `tools\\log_create_win.cmd` to create log directories.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
-- Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; it now records service URLs and API keys in `.env`. Use `remove_full.cmd` to uninstall, remove the environment, drop tables, and purge these credentials.
+- Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; it now records service URLs and API keys in `.env` and invokes `tools\\log_create_win.cmd` at startup. Use `remove_full.cmd` to uninstall, remove the environment, drop tables, and purge these credentials.
 - Each service provides `install.sh` and `remove.sh` scripts.
 - Each service now ships with its own `requirements.txt` for Docker builds.
 - Requirements now include `web3` for on-chain interactions.


### PR DESCRIPTION
## Summary
- ensure setup_env.cmd and setup_full.cmd run tools\log_create_win.cmd at startup
- document Windows log initialization
- record installer changes in changelog

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a640047a24832c9174a00f37172104