### PR TITLE
feat: add optional demo data seeding and checks

### DIFF
--- a/admin/db_check.php
+++ b/admin/db_check.php
@@ -1,6 +1,6 @@
 <?php
-// db_check.php v0.1.17 (2025-08-20)
-$expectedVersion = 'v0.1.14';
+// db_check.php v0.1.18 (2025-02-14)
+$expectedVersion = 'v0.1.15';
 $dsn = sprintf('pgsql:host=%s;port=%s;dbname=%s',
     getenv('DB_HOST') ?: 'localhost',
     getenv('DB_PORT') ?: '5432',
@@ -10,7 +10,7 @@ $pass = getenv('DB_PASS') ?: '';
 $requiredTables = [
     'users','goals','accounts','portfolios','positions','orders',
     'executions','prices','signals','actions','risk_limits','metrics_daily',
-    'backtests','risk_stress_results','notifications','alerts','strategies','strategy_reviews','audit_events','scenario_results','macro_indicators'
+    'backtests','risk_stress_results','notifications','alerts','strategies','strategy_reviews','audit_events','scenario_results','macro_indicators','demo_users'
 ];
 $warehouseTables = ['dw_orders','dw_positions'];
 $priceColumns = ['symbol','venue','ts','o','h','l','c','v'];
@@ -171,8 +171,13 @@ $cols = $stmt->fetchAll(PDO::FETCH_COLUMN);
           echo "Missing column in macro_indicators: $col\n";
           exit(1);
       }
+    }
+  $demoCount = $pdo->query("SELECT COUNT(*) FROM demo_users")->fetchColumn();
+  if ($demoCount == 0) {
+      echo "Missing demo data in demo_users\n";
+      exit(1);
   }
-$schemaVersion = getenv('DB_SCHEMA_VERSION') ?: 'unknown';
+  $schemaVersion = getenv('DB_SCHEMA_VERSION') ?: 'unknown';
 if ($schemaVersion !== $expectedVersion) {
     echo "Schema version mismatch: expected $expectedVersion, got $schemaVersion\n";
     exit(1);

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.68
+# Changelog v0.6.69
 =======
 
 
@@ -13,6 +13,7 @@
 - Introduced user manual revision with installation, usage, architecture and troubleshooting sections.
 - Cross-linked README and user manual.
 - Bumped README to v0.1.1 and user manual/changelog to v0.6.0.
+- Added optional demo data seeding via `setup_full.cmd` applying `db/seeds/*.sql` and validating with `admin/db_check.php`; log creation scripts, user manual and versions updated.
 
 ## 2025-08-19
 - Added shared monitoring utilities providing JSON logging, Prometheus metrics and OpenTelemetry traces.

--- a/db/seeds/demo_users.sql
+++ b/db/seeds/demo_users.sql
@@ -1,0 +1,8 @@
+-- demo_users.sql v0.1.0 (2025-02-14)
+CREATE TABLE IF NOT EXISTS demo_users (
+    id SERIAL PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
+INSERT INTO demo_users (email) VALUES ('demo@example.com') ON CONFLICT DO NOTHING;

--- a/setup_full.cmd
+++ b/setup_full.cmd
@@ -1,5 +1,5 @@
 @echo off
-rem setup_full.cmd v0.1.5 (2025-08-20)
+rem setup_full.cmd v0.1.6 (2025-02-14)
 
 call tools\log_create_win.cmd
 
@@ -88,6 +88,14 @@ psql -h %DB_HOST% -p %DB_PORT% -U %DB_USER% -d %DB_NAME% -c "CREATE EXTENSION IF
 for %%f in (db\migrations\*.sql) do (
   echo Applying %%f
   psql -h %DB_HOST% -p %DB_PORT% -U %DB_USER% -d %DB_NAME% -f %%f
+)
+set /p LOAD_DEMO="Load demonstration data (db\\seeds\\*.sql)? [y/N]: "
+if /I "%LOAD_DEMO%"=="Y" (
+  echo Inserting demonstration data...
+  for %%f in (db\seeds\*.sql) do (
+    echo Applying %%f
+    psql -h %DB_HOST% -p %DB_PORT% -U %DB_USER% -d %DB_NAME% -f %%f
+  )
 )
 set PGPASSWORD=
 

--- a/tools/log_create.sh
+++ b/tools/log_create.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# log directory creator v0.6.32 (2025-08-20)
+# log directory creator v0.6.33 (2025-02-14)
 set -e
 mkdir -p logs
 mkdir -p logs/containers
@@ -11,6 +11,7 @@ mkdir -p perf
 mkdir -p perf/reports
 mkdir -p execution-engine/logs
 mkdir -p infra/terraform/logs
+mkdir -p db/seeds
 mkdir -p logs/notification-service
 mkdir -p logs/strategy-marketplace
 mkdir -p logs/fx-service
@@ -51,3 +52,4 @@ touch logs/kyc-service/kyc.log
 touch logs/alert-engine/alert.log
 touch logs/macro-service/macro.log
 touch logs/whatif-service/whatif.log
+touch db/seeds/.gitkeep

--- a/tools/log_create_win.cmd
+++ b/tools/log_create_win.cmd
@@ -1,5 +1,5 @@
 @echo off
-REM log directory creator v0.6.32 (2025-08-20)
+REM log directory creator v0.6.33 (2025-02-14)
 mkdir logs 2>nul
 mkdir logs\containers 2>nul
 mkdir logs\analytics 2>nul
@@ -10,6 +10,7 @@ mkdir perf 2>nul
 mkdir perf\reports 2>nul
 mkdir execution-engine\logs 2>nul
 mkdir infra\terraform\logs 2>nul
+mkdir db\seeds 2>nul
 mkdir logs\notification-service 2>nul
 mkdir logs\strategy-marketplace 2>nul
 mkdir logs\fx-service 2>nul
@@ -50,3 +51,4 @@ type nul > logs\kyc-service\kyc.log
 type nul > logs\alert-engine\alert.log
 type nul > logs\macro-service\macro.log
 type nul > logs\whatif-service\whatif.log
+type nul > db\seeds\.gitkeep

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,8 +1,8 @@
-# User Manual v0.6.69
+# User Manual v0.6.70
 =======
 
 
-Date: 2025-08-20
+Date: 2025-02-14
 
 This document will evolve into a comprehensive encyclopedia for the project.
 
@@ -23,6 +23,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies; the Windows script now invokes `tools\\log_create_win.cmd` to create log directories.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
 - Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; it now records service URLs and API keys in `.env` and invokes `tools\\log_create_win.cmd` at startup. Use `remove_full.cmd` to uninstall, remove the environment, drop tables, and purge these credentials.
+- After migrations, `setup_full.cmd` can optionally apply demonstration SQL files from `db/seeds/*.sql` to populate sample data.
 - Each service provides `install.sh` and `remove.sh` scripts.
 - Each service now ships with its own `requirements.txt` for Docker builds.
 - Requirements now include `web3` for on-chain interactions.


### PR DESCRIPTION
## Summary
- add optional demo data seeding block in Windows setup script
- validate demo seed table and data in db_check
- document demo seed usage and maintain log creation scripts

## Testing
- `php -l admin/db_check.php`
- `bash -n tools/log_create.sh`
- `npm test` *(fails: Missing script "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a641b6d68c832c83b439799e4653ed