### PR TITLE
Update Windows setup scripts to manage .env

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.72
+# Changelog v0.6.73
 =======
 
 
@@ -252,3 +252,4 @@
 - setup_env.cmd and setup_full.cmd now invoke `tools\\log_create_win.cmd` at startup to create log directories.
 - Added IsolationForest-based anomaly detection persisting anomalies in `risk_anomalies` and emitting `risk_anomaly` events to alert-engine with migration, schema checks, log script and documentation updates.
 - Hardened randomness and subprocess usage in orchestrator, reporting and strategy-marketplace to satisfy Bandit security checks.
+- setup_full.cmd now creates or updates `.env` immediately after prompts, replacing database placeholders, and remove_full.cmd clears these `.env` entries; versions bumped.

--- a/remove_full.cmd
+++ b/remove_full.cmd
@@ -1,5 +1,5 @@
 @echo off
-rem remove_full.cmd v0.1.5 (2025-08-20)
+rem remove_full.cmd v0.1.6 (2025-08-20)
 
 set "SILENT=0"
 set "CONFIG_FILE="
@@ -101,7 +101,7 @@ if %ERRORLEVEL%==0 (
 if exist .env (
   echo Clearing service credentials from .env...
   powershell -Command ^
-    "$envpath='.env'; $vars = 'RABBITMQ_URL','API_GATEWAY_URL','ALPHA_VANTAGE_KEY','BINANCE_API_KEY','BINANCE_API_SECRET','IBKR_API_KEY','FRED_API_KEY'; $content = Get-Content $envpath; foreach($k in $vars){$pattern = '^' + [regex]::Escape($k) + '='; if($content -match $pattern){$content = $content -replace $pattern + '.*', $k + '='}}; Set-Content $envpath $content"
+    "$envpath='.env'; $vars = 'DB_HOST','DB_PORT','DB_NAME','DB_USER','DB_PASS','RABBITMQ_URL','API_GATEWAY_URL','ALPHA_VANTAGE_KEY','BINANCE_API_KEY','BINANCE_API_SECRET','IBKR_API_KEY','FRED_API_KEY'; $content = Get-Content $envpath; foreach($k in $vars){$pattern = '^' + [regex]::Escape($k) + '='; if($content -match $pattern){$content = $content -replace $pattern + '.*', $k + '='}}; Set-Content $envpath $content"
 )
 
 echo Removal complete.

--- a/setup_full.cmd
+++ b/setup_full.cmd
@@ -1,5 +1,5 @@
 @echo off
-rem setup_full.cmd v0.1.7 (2025-08-20)
+rem setup_full.cmd v0.1.8 (2025-08-20)
 
 if not exist logs mkdir logs
 set LOG_FILE=logs\setup_full.log
@@ -102,15 +102,6 @@ if "%SILENT%"=="0" if not defined CONFIG_FILE set /p FRED_API_KEY="Enter FRED AP
 if "%FRED_API_KEY%"=="" set "FRED_API_KEY=demo"
 if "%SILENT%"=="0" if not defined CONFIG_FILE set /p LOAD_DEMO="Load demonstration data (db\\seeds\\*.sql)? [y/N]: "
 
-echo Creating Python virtual environment...
-if not exist venv (
-  python -m venv venv
-)
-call venv\Scripts\activate
-
-echo Installing Python dependencies...
-pip install -r "%~dp0requirements.txt"
-
 if not exist .env (
   echo Creating .env from sample...
   copy .env.example .env >nul
@@ -124,6 +115,15 @@ powershell -Command ^
   "$content = Get-Content $envpath;" ^
   "foreach($k in $vars.Keys){$pattern = '^' + [regex]::Escape($k) + '='; $replacement = \"$k=$($vars[$k])\"; if($content -match $pattern){$content = $content -replace $pattern + '.*', $replacement} else {$content += $replacement}};" ^
   "Set-Content $envpath $content"
+
+echo Creating Python virtual environment...
+if not exist venv (
+  python -m venv venv
+)
+call venv\Scripts\activate
+
+echo Installing Python dependencies...
+pip install -r "%~dp0requirements.txt"
 
 echo Creating and migrating database...
 set PGPASSWORD=%DB_PASS%

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.73
+# User Manual v0.6.74
 =======
 
 
@@ -16,13 +16,13 @@ This document will evolve into a comprehensive encyclopedia for the project.
   - PostgreSQL `psql`
   - Docker
   - Node.js
-- `setup_full.cmd` checks for these tools, prompts for database, RabbitMQ, API Gateway and API keys, writing values to `.env`, and opens download pages if any are missing. The script now writes all output to `logs\\setup_full.log` and accepts a `--silent` flag or `--config <file>` to skip prompts.
+- `setup_full.cmd` checks for these tools, prompts for database, RabbitMQ, API Gateway and API keys, writing values to `.env`, and opens download pages if any are missing. The script now writes all output to `logs\\setup_full.log` and accepts a `--silent` flag or `--config <file>` to skip prompts. After prompts it creates `.env` if missing and replaces database placeholders with the provided values.
 - Copy `.env.example` to `.env` and adjust values as needed, including `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, `RATE_LIMIT_PER_MINUTE`, `ALPHA_VANTAGE_KEY`, `BINANCE_API_KEY`, `BINANCE_API_SECRET`, `IBKR_API_KEY` and `FRED_API_KEY`.
 - Configure OAuth token endpoints via `GOOGLE_TOKEN_URL` and `GITHUB_TOKEN_URL` if overriding defaults.
 - Set `KYC_HOST` to control the bind address of the KYC service (defaults to `127.0.0.1`).
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies; the Windows script now invokes `tools\\log_create_win.cmd` to create log directories.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
-- Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; it now records service URLs and API keys in `.env` and invokes `tools\\log_create_win.cmd` at startup. Use `--silent` to accept defaults or `--config <file>` to supply answers, and all output is logged to `logs\\setup_full.log`. Use `remove_full.cmd` with the same flags to uninstall, remove the environment, drop tables, and purge these credentials.
+- Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; it now records service URLs and API keys in `.env` and invokes `tools\\log_create_win.cmd` at startup. Use `--silent` to accept defaults or `--config <file>` to supply answers, and all output is logged to `logs\\setup_full.log`. Use `remove_full.cmd` with the same flags to uninstall, remove the environment, drop tables, and purge these credentials, including database connection entries.
 - After migrations, `setup_full.cmd` can optionally apply demonstration SQL files from `db/seeds/*.sql` to populate sample data.
 - Each service provides `install.sh` and `remove.sh` scripts.
 - Each service now ships with its own `requirements.txt` for Docker builds.


### PR DESCRIPTION
## Summary
- update setup_full.cmd to create or update .env after prompts and bump to v0.1.8
- extend remove_full.cmd to wipe DB settings from .env and bump to v0.1.6
- document .env handling in changelog and user manual

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a651f57c18832ca1491a43d7ff64e4