### PR TITLE
build ui during setup and clean on removal

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.73
+# Changelog v0.6.74
 =======
 
 
@@ -234,6 +234,7 @@
 - Performance script now fails fast if risk-engine health check fails.
 - Replaced Stable Baselines3 optimizer with a lightweight heuristic in `rl_optimizer.py` and updated tests and documentation.
 
+
 - Added alert-engine service consuming risk metrics and forwarding alerts to notification-service.
 - Created alerts table with migration and schema checks in admin/db_check.php.
 - Exposed /alerts/subscribe in api-gateway and added UI subscription page.
@@ -253,3 +254,4 @@
 - Added IsolationForest-based anomaly detection persisting anomalies in `risk_anomalies` and emitting `risk_anomaly` events to alert-engine with migration, schema checks, log script and documentation updates.
 - Hardened randomness and subprocess usage in orchestrator, reporting and strategy-marketplace to satisfy Bandit security checks.
 - setup_full.cmd now creates or updates `.env` immediately after prompts, replacing database placeholders, and remove_full.cmd clears these `.env` entries; versions bumped.
+- setup_full.cmd now installs UI dependencies and builds the Next.js frontend while remove_full.cmd deletes `ui` node_modules and `.next` directories.

--- a/remove_full.cmd
+++ b/remove_full.cmd
@@ -1,5 +1,5 @@
 @echo off
-rem remove_full.cmd v0.1.6 (2025-08-20)
+rem remove_full.cmd v0.1.7 (2025-08-20)
 
 set "SILENT=0"
 set "CONFIG_FILE="
@@ -96,6 +96,14 @@ if %ERRORLEVEL%==0 (
   docker compose down 2>nul || docker-compose down
 ) else (
   echo Docker not found, skipping container stop.
+)
+
+echo Removing UI dependencies and build artifacts...
+if exist ui (
+  pushd ui
+  if exist node_modules rmdir /s /q node_modules
+  if exist .next rmdir /s /q .next
+  popd
 )
 
 if exist .env (

--- a/setup_full.cmd
+++ b/setup_full.cmd
@@ -1,5 +1,5 @@
 @echo off
-rem setup_full.cmd v0.1.8 (2025-08-20)
+rem setup_full.cmd v0.1.9 (2025-08-20)
 
 if not exist logs mkdir logs
 set LOG_FILE=logs\setup_full.log
@@ -141,6 +141,12 @@ if /I "%LOAD_DEMO%"=="Y" (
   )
 )
 set PGPASSWORD=
+
+echo Installing UI dependencies and building...
+pushd ui
+npm install
+npm run build
+popd
 
 echo Starting services with Docker...
 where docker >nul 2>nul

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.74
+# User Manual v0.6.75
 =======
 
 
@@ -22,7 +22,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Set `KYC_HOST` to control the bind address of the KYC service (defaults to `127.0.0.1`).
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies; the Windows script now invokes `tools\\log_create_win.cmd` to create log directories.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
-- Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; it now records service URLs and API keys in `.env` and invokes `tools\\log_create_win.cmd` at startup. Use `--silent` to accept defaults or `--config <file>` to supply answers, and all output is logged to `logs\\setup_full.log`. Use `remove_full.cmd` with the same flags to uninstall, remove the environment, drop tables, and purge these credentials, including database connection entries.
+- Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; it now records service URLs and API keys in `.env`, invokes `tools\\log_create_win.cmd` at startup, installs UI dependencies and builds the frontend. Use `--silent` to accept defaults or `--config <file>` to supply answers, and all output is logged to `logs\\setup_full.log`. Use `remove_full.cmd` with the same flags to uninstall, remove the environment, drop tables, purge these credentials, and delete UI `node_modules` and `.next` directories.
 - After migrations, `setup_full.cmd` can optionally apply demonstration SQL files from `db/seeds/*.sql` to populate sample data.
 - Each service provides `install.sh` and `remove.sh` scripts.
 - Each service now ships with its own `requirements.txt` for Docker builds.


### PR DESCRIPTION
## Summary
- run `npm install` and `npm run build` in the UI during `setup_full.cmd`
- remove UI `node_modules` and `.next` directories in `remove_full.cmd`
- document and record these steps in changelog and user manual

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a653b20590832c9411d808c31c505e