### PR TITLE
Verify database schema during Windows setup

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.74
+# Changelog v0.6.75
 =======
 
 
@@ -255,3 +255,4 @@
 - Hardened randomness and subprocess usage in orchestrator, reporting and strategy-marketplace to satisfy Bandit security checks.
 - setup_full.cmd now creates or updates `.env` immediately after prompts, replacing database placeholders, and remove_full.cmd clears these `.env` entries; versions bumped.
 - setup_full.cmd now installs UI dependencies and builds the Next.js frontend while remove_full.cmd deletes `ui` node_modules and `.next` directories.
+- setup_full.cmd now verifies database schema with `php admin\\db_check.php` after migrations and aborts on failure.

--- a/setup_full.cmd
+++ b/setup_full.cmd
@@ -1,5 +1,5 @@
 @echo off
-rem setup_full.cmd v0.1.9 (2025-08-20)
+rem setup_full.cmd v0.1.10 (2025-08-20)
 
 if not exist logs mkdir logs
 set LOG_FILE=logs\setup_full.log
@@ -141,6 +141,13 @@ if /I "%LOAD_DEMO%"=="Y" (
   )
 )
 set PGPASSWORD=
+
+echo Verifying database schema...
+php admin\db_check.php
+if %ERRORLEVEL% neq 0 (
+  echo Database verification failed.
+  exit /b %ERRORLEVEL%
+)
 
 echo Installing UI dependencies and building...
 pushd ui

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.75
+# User Manual v0.6.76
 =======
 
 
@@ -24,6 +24,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
 - Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; it now records service URLs and API keys in `.env`, invokes `tools\\log_create_win.cmd` at startup, installs UI dependencies and builds the frontend. Use `--silent` to accept defaults or `--config <file>` to supply answers, and all output is logged to `logs\\setup_full.log`. Use `remove_full.cmd` with the same flags to uninstall, remove the environment, drop tables, purge these credentials, and delete UI `node_modules` and `.next` directories.
 - After migrations, `setup_full.cmd` can optionally apply demonstration SQL files from `db/seeds/*.sql` to populate sample data.
+- The script then verifies the database schema with `php admin\\db_check.php` and aborts if inconsistencies are found.
 - Each service provides `install.sh` and `remove.sh` scripts.
 - Each service now ships with its own `requirements.txt` for Docker builds.
 - Requirements now include `web3` for on-chain interactions.


### PR DESCRIPTION
## Summary
- run php admin\\db_check.php after migrations in setup_full.cmd and abort on failure
- document database verification in changelog and user manual

## Testing
- `npm test` (fails: Missing script: "test")
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a655eea40c832c88327b093b1c3e35