### PR TITLE
feat: track db schema version

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# .env.example v0.1.9 (2025-08-20)
+# .env.example v0.1.10 (2025-08-20)
 SECRET_KEY=change_me
 REMOTE_LOG_URL=
 API_GATEWAY_METRICS_PORT=9001
@@ -8,6 +8,7 @@ DB_PORT=5432
 DB_NAME=cashmachiine
 DB_USER=postgres
 DB_PASS=
+DB_SCHEMA_VERSION=v0.1.7
 RISK_ENGINE_URL=http://localhost:8000
 API_GATEWAY_URL=http://localhost:8000
 REDIS_HOST=localhost

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.77
+# Changelog v0.6.78
 =======
 
 
@@ -258,3 +258,4 @@
 - setup_full.cmd now verifies database schema with `php admin\\db_check.php` after migrations and aborts on failure.
 - setup_full.cmd adds error-checked sections with rollback to drop the database, uninstall dependencies and stop containers; errors are logged to `logs\\setup_full.log`, and remove_full.cmd drops the database.
 - setup_full.cmd now applies warehouse migrations from `db/migrations/warehouse/*.sql` after core migrations.
+- Introduced `DB_SCHEMA_VERSION` (`v0.1.7`) in `.env.example`, propagated by `setup_full.cmd`, with documentation updates.

--- a/setup_full.cmd
+++ b/setup_full.cmd
@@ -1,5 +1,5 @@
 @echo off
-rem setup_full.cmd v0.1.12 (2025-08-20)
+rem setup_full.cmd v0.1.13 (2025-08-20)
 
 if not exist logs mkdir logs
 set LOG_FILE=logs\setup_full.log
@@ -112,7 +112,7 @@ if not exist .env (
 echo Updating .env with provided values...
 powershell -Command ^
   "$envpath='.env';" ^
-  "$vars = @{'DB_HOST'='%DB_HOST%'; 'DB_PORT'='%DB_PORT%'; 'DB_NAME'='%DB_NAME%'; 'DB_USER'='%DB_USER%'; 'DB_PASS'='%DB_PASS%'; 'RABBITMQ_URL'='%RABBITMQ_URL%'; 'API_GATEWAY_URL'='%API_GATEWAY_URL%'; 'ALPHA_VANTAGE_KEY'='%ALPHA_VANTAGE_KEY%'; 'BINANCE_API_KEY'='%BINANCE_API_KEY%'; 'BINANCE_API_SECRET'='%BINANCE_API_SECRET%'; 'IBKR_API_KEY'='%IBKR_API_KEY%'; 'FRED_API_KEY'='%FRED_API_KEY%'};" ^
+  "$vars = @{'DB_HOST'='%DB_HOST%'; 'DB_PORT'='%DB_PORT%'; 'DB_NAME'='%DB_NAME%'; 'DB_USER'='%DB_USER%'; 'DB_PASS'='%DB_PASS%'; 'DB_SCHEMA_VERSION'='v0.1.7'; 'RABBITMQ_URL'='%RABBITMQ_URL%'; 'API_GATEWAY_URL'='%API_GATEWAY_URL%'; 'ALPHA_VANTAGE_KEY'='%ALPHA_VANTAGE_KEY%'; 'BINANCE_API_KEY'='%BINANCE_API_KEY%'; 'BINANCE_API_SECRET'='%BINANCE_API_SECRET%'; 'IBKR_API_KEY'='%IBKR_API_KEY%'; 'FRED_API_KEY'='%FRED_API_KEY%'};" ^
   "if(!(Test-Path $envpath)){New-Item $envpath -ItemType File | Out-Null};" ^
   "$content = Get-Content $envpath;" ^
   "foreach($k in $vars.Keys){$pattern = '^' + [regex]::Escape($k) + '='; $replacement = \"$k=$($vars[$k])\"; if($content -match $pattern){$content = $content -replace $pattern + '.*', $replacement} else {$content += $replacement}};" ^

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.78
+# User Manual v0.6.79
 =======
 
 
@@ -18,6 +18,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
   - Node.js
 - `setup_full.cmd` checks for these tools, prompts for database, RabbitMQ, API Gateway and API keys, writing values to `.env`, and opens download pages if any are missing. The script now writes all output to `logs\\setup_full.log` and accepts a `--silent` flag or `--config <file>` to skip prompts. After prompts it creates `.env` if missing and replaces database placeholders with the provided values.
 - Copy `.env.example` to `.env` and adjust values as needed, including `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, `RATE_LIMIT_PER_MINUTE`, `ALPHA_VANTAGE_KEY`, `BINANCE_API_KEY`, `BINANCE_API_SECRET`, `IBKR_API_KEY` and `FRED_API_KEY`.
+- `DB_SCHEMA_VERSION` records the expected database schema revision (`v0.1.7`) checked by `admin/db_check.php`.
 - Configure OAuth token endpoints via `GOOGLE_TOKEN_URL` and `GITHUB_TOKEN_URL` if overriding defaults.
 - Set `KYC_HOST` to control the bind address of the KYC service (defaults to `127.0.0.1`).
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies; the Windows script now invokes `tools\\log_create_win.cmd` to create log directories.


### PR DESCRIPTION
## Summary
- add `DB_SCHEMA_VERSION` sample env var
- propagate db schema version in `setup_full.cmd`
- document DB schema version and update changelog

## Testing
- `npm test` (fails: Missing script "test")
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a65dc8908c832cbf708d63d6318759