### PR TITLE
feat: verify docker health

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.80
+# Changelog v0.6.81
 =======
 
 
@@ -38,6 +38,9 @@
 - Added RabbitMQ-based messaging package with producers and consumers.
 - Orchestrator now publishes events to the bus; data-ingestion consumes them.
 - Added broker installer scripts and `pika` dependency with configuration.
+
+## 2025-08-21
+- Setup scripts now wait for Docker containers to become healthy and roll back on failure.
 - Added Dockerfiles for all services with version headers.
 - Introduced root docker-compose.yml wiring services, database, cache and message bus.
 - Updated setup/remove scripts to invoke `docker-compose up` and `docker-compose down`.

--- a/changelog_2025-08-21.md
+++ b/changelog_2025-08-21.md
@@ -1,6 +1,7 @@
-# Changelog v0.6.80
+# Changelog v0.6.81
 
 ## 2025-08-21
 - `setup_full.cmd` now detects missing `psql` or TimescaleDB and launches a `timescale/timescaledb` container with the provided credentials.
 - `remove_full.cmd` stops and removes this TimescaleDB container during cleanup.
 - Documented container usage in the user manual and bumped script and documentation versions.
+- Setup scripts now wait for Docker containers to become healthy and roll back on failure.

--- a/setup_env.cmd
+++ b/setup_env.cmd
@@ -1,5 +1,5 @@
 @echo off
-rem setup_env.cmd v0.2.4 (2025-08-20)
+rem setup_env.cmd v0.2.5 (2025-08-21)
 
 call tools\log_create_win.cmd
 
@@ -10,4 +10,9 @@ if not exist .env if exist .env.example copy .env.example .env
 where docker >nul 2>nul
 if %ERRORLEVEL%==0 (
   docker compose up -d 2>nul || docker-compose up -d
+  powershell -NoProfile -Command "$timeout=120;$interval=5;$elapsed=0;while($elapsed -lt $timeout){$ps=(docker compose ps --format '{{.Service}} {{.State}}' 2>$null);if($LASTEXITCODE -ne 0){$ps=(docker-compose ps --format '{{.Service}} {{.State}}' 2>$null)};if($ps -match 'unhealthy|exited'){exit 1};if($ps -notmatch 'healthy'){Start-Sleep -Seconds $interval;$elapsed+=$interval}else{exit 0}};exit 1"
+  if %ERRORLEVEL% neq 0 (
+    docker compose down 2>nul || docker-compose down 2>nul
+    exit /b 1
+  )
 )

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# setup_env.sh v0.2.3 (2025-08-20)
+# setup_env.sh v0.2.4 (2025-08-21)
 
 set -e
 
@@ -9,8 +9,39 @@ if [ ! -f .env ] && [ -f .env.example ]; then
   cp .env.example .env
 fi
 
+rollback() {
+  docker compose down 2>/dev/null || docker-compose down 2>/dev/null || true
+}
+
+wait_for_healthy() {
+  local timeout=120
+  local interval=5
+  local elapsed=0
+  while [ "$elapsed" -lt "$timeout" ]; do
+    local status
+    status=$(docker compose ps --format '{{.Service}} {{.State}}' 2>/dev/null || docker-compose ps --format '{{.Service}} {{.State}}')
+    echo "$status"
+    if echo "$status" | grep -q "unhealthy"; then
+      echo "Detected unhealthy container" >&2
+      rollback
+      exit 1
+    fi
+    if echo "$status" | grep -qv "healthy"; then
+      sleep "$interval"
+      elapsed=$((elapsed + interval))
+      continue
+    fi
+    return 0
+  done
+  echo "Timeout waiting for containers to become healthy" >&2
+  rollback
+  exit 1
+}
+
 if command -v docker >/dev/null 2>&1; then
   docker compose up -d || docker-compose up -d
+  wait_for_healthy
 elif command -v docker-compose >/dev/null 2>&1; then
   docker-compose up -d
+  wait_for_healthy
 fi

--- a/setup_full.cmd
+++ b/setup_full.cmd
@@ -1,5 +1,5 @@
 @echo off
-rem setup_full.cmd v0.1.15 (2025-08-21)
+rem setup_full.cmd v0.1.16 (2025-08-21)
 
 if not exist logs mkdir logs
 set LOG_FILE=logs\setup_full.log
@@ -216,6 +216,11 @@ if %ERRORLEVEL%==0 (
   docker compose up -d 2>nul || docker-compose up -d
   if %ERRORLEVEL% neq 0 (
     set "ERROR_MSG=Docker startup failed."
+    goto cleanup
+  )
+  powershell -NoProfile -Command "$timeout=120;$interval=5;$elapsed=0;while($elapsed -lt $timeout){$ps=(docker compose ps --format '{{.Service}} {{.State}}' 2>$null);if($LASTEXITCODE -ne 0){$ps=(docker-compose ps --format '{{.Service}} {{.State}}' 2>$null)};if($ps -match 'unhealthy|exited'){exit 1};if($ps -notmatch 'healthy'){Start-Sleep -Seconds $interval;$elapsed+=$interval}else{exit 0}};exit 1"
+  if %ERRORLEVEL% neq 0 (
+    set "ERROR_MSG=Container health check failed."
     goto cleanup
   )
 ) else (

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.81
+# User Manual v0.6.82
 =======
 
 
@@ -35,6 +35,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Mobile dependencies install with `mobile/install.sh` and remove with `mobile/remove.sh`; build logs output to `logs/mobile/`.
 - Install RabbitMQ with `./install_rabbitmq.sh` and remove it with `./remove_rabbitmq.sh`.
 - Start all services with `docker-compose up -d` and stop them with `docker-compose down`.
+- Setup scripts wait for Docker containers to report healthy status and roll back if any container fails.
 - Run `./install_db.sh` to apply migrations; the script enables TimescaleDB and converts `prices` to a hypertable.
 - Create PostgreSQL dumps with `tools/db_backup.sh --retention <days>` (default 7) which stores files under `backups/` and prunes old ones.
 - Restore a dump via `tools/db_restore.sh <dump_file>`.

--- a/user_manual_2025-08-21.md
+++ b/user_manual_2025-08-21.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.81
+# User Manual v0.6.82
 =======
 
 
@@ -35,6 +35,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Mobile dependencies install with `mobile/install.sh` and remove with `mobile/remove.sh`; build logs output to `logs/mobile/`.
 - Install RabbitMQ with `./install_rabbitmq.sh` and remove it with `./remove_rabbitmq.sh`.
 - Start all services with `docker-compose up -d` and stop them with `docker-compose down`.
+- Setup scripts wait for Docker containers to report healthy status and roll back if any container fails.
 - Run `./install_db.sh` to apply migrations; the script enables TimescaleDB and converts `prices` to a hypertable.
 - Create PostgreSQL dumps with `tools/db_backup.sh --retention <days>` (default 7) which stores files under `backups/` and prunes old ones.
 - Restore a dump via `tools/db_restore.sh <dump_file>`.


### PR DESCRIPTION
## Summary
- ensure setup scripts wait for healthy Docker containers and roll back on failure
- document new container health checks
- record update in changelogs

## Testing
- `bash -n setup_env.sh`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6648b61cc832c80a3074609efbe09