### PR TITLE
Use secure PowerShell DB password prompt

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.81
+# Changelog v0.6.82
 =======
 
 
@@ -271,3 +271,4 @@
 - `setup_full.cmd` now detects missing `psql` or TimescaleDB and launches a `timescale/timescaledb` container with the provided credentials.
 - `remove_full.cmd` stops and removes this TimescaleDB container during cleanup.
 - Documented container usage in the user manual and bumped script and documentation versions.
+- Replaced plaintext database password prompts with a PowerShell secure input in `setup_full.cmd` and `remove_full.cmd`.

--- a/changelog_2025-08-21.md
+++ b/changelog_2025-08-21.md
@@ -1,7 +1,8 @@
-# Changelog v0.6.81
+# Changelog v0.6.82
 
 ## 2025-08-21
 - `setup_full.cmd` now detects missing `psql` or TimescaleDB and launches a `timescale/timescaledb` container with the provided credentials.
 - `remove_full.cmd` stops and removes this TimescaleDB container during cleanup.
 - Documented container usage in the user manual and bumped script and documentation versions.
+- Replaced plaintext database password prompts with a PowerShell secure input in `setup_full.cmd` and `remove_full.cmd`.
 - Setup scripts now wait for Docker containers to become healthy and roll back on failure.

--- a/remove_full.cmd
+++ b/remove_full.cmd
@@ -1,5 +1,5 @@
 @echo off
-rem remove_full.cmd v0.1.9 (2025-08-21)
+rem remove_full.cmd v0.1.10 (2025-08-21)
 
 set "SILENT=0"
 set "CONFIG_FILE="
@@ -74,7 +74,7 @@ if "%SILENT%"=="0" if not defined CONFIG_FILE set /p DB_NAME="Enter database nam
 if "%DB_NAME%"=="" set DB_NAME=cashmachiine
 if "%SILENT%"=="0" if not defined CONFIG_FILE set /p DB_USER="Enter database user [%DB_USER%]: "
 if "%DB_USER%"=="" set DB_USER=postgres
-if "%SILENT%"=="0" if not defined CONFIG_FILE set /p DB_PASS="Enter database password: "
+if "%SILENT%"=="0" if not defined CONFIG_FILE for /f "usebackq delims=" %%p in (`powershell -Command "$p = Read-Host 'Enter database password' -AsSecureString; $BSTR=[System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($p); [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($BSTR)"`) do set DB_PASS=%%p
 
 echo Dropping database %DB_NAME%...
 set PGPASSWORD=%DB_PASS%

--- a/setup_full.cmd
+++ b/setup_full.cmd
@@ -1,5 +1,5 @@
 @echo off
-rem setup_full.cmd v0.1.16 (2025-08-21)
+rem setup_full.cmd v0.1.17 (2025-08-21)
 
 if not exist logs mkdir logs
 set LOG_FILE=logs\setup_full.log
@@ -110,7 +110,7 @@ if "%SILENT%"=="0" if not defined CONFIG_FILE set /p DB_NAME="Enter database nam
 if "%DB_NAME%"=="" set "DB_NAME=cashmachiine"
 if "%SILENT%"=="0" if not defined CONFIG_FILE set /p DB_USER="Enter database user [%DB_USER%]: "
 if "%DB_USER%"=="" set "DB_USER=postgres"
-if "%SILENT%"=="0" if not defined CONFIG_FILE set /p DB_PASS="Enter database password: "
+if "%SILENT%"=="0" if not defined CONFIG_FILE for /f "usebackq delims=" %%p in (`powershell -Command "$p = Read-Host 'Enter database password' -AsSecureString; $BSTR=[System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($p); [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($BSTR)"`) do set DB_PASS=%%p
 if "%SILENT%"=="0" if not defined CONFIG_FILE set /p RABBITMQ_URL="Enter RabbitMQ URL [%RABBITMQ_URL%]: "
 if "%RABBITMQ_URL%"=="" set "RABBITMQ_URL=amqp://guest:guest@localhost:5672/"
 if "%SILENT%"=="0" if not defined CONFIG_FILE set /p API_GATEWAY_URL="Enter API Gateway URL [%API_GATEWAY_URL%]: "

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.82
+# User Manual v0.6.83
 =======
 
 
@@ -23,7 +23,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Set `KYC_HOST` to control the bind address of the KYC service (defaults to `127.0.0.1`).
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies; the Windows script now invokes `tools\\log_create_win.cmd` to create log directories.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
-- Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; it now records service URLs and API keys in `.env`, invokes `tools\\log_create_win.cmd` at startup, installs UI dependencies and builds the frontend. The script rolls back on any failure by dropping the database, uninstalling dependencies and stopping containers while logging errors to `logs\setup_full.log`. Use `--silent` to accept defaults, `--config <file>` to supply answers, or `--seed` to execute SQL seed files without prompting. All output is logged to `logs\setup_full.log`. Use `remove_full.cmd` with the same flags to uninstall, remove the environment, drop the database, purge these credentials, delete UI `node_modules` and `.next` directories, and stop and remove the TimescaleDB container.
+- Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; it now records service URLs and API keys in `.env`, invokes `tools\\log_create_win.cmd` at startup, installs UI dependencies and builds the frontend. The script rolls back on any failure by dropping the database, uninstalling dependencies and stopping containers while logging errors to `logs\setup_full.log`. Use `--silent` to accept defaults, `--config <file>` to supply answers, or `--seed` to execute SQL seed files without prompting. All output is logged to `logs\setup_full.log`. Use `remove_full.cmd` with the same flags to uninstall, remove the environment, drop the database, purge these credentials, delete UI `node_modules` and `.next` directories, and stop and remove the TimescaleDB container. Both scripts now capture the database password via a PowerShell secure prompt that hides the input.
 - After base migrations, `setup_full.cmd` applies warehouse schema migrations from `db/migrations/warehouse/*.sql`.
 - After migrations, `setup_full.cmd` can optionally execute seed SQL files from `db/seeds/*.sql` (admin user, demo accounts) to populate sample data.
 - The script then verifies the database schema with `php admin\\db_check.php` and aborts if inconsistencies are found.

--- a/user_manual_2025-08-21.md
+++ b/user_manual_2025-08-21.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.82
+# User Manual v0.6.83
 =======
 
 
@@ -23,7 +23,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Set `KYC_HOST` to control the bind address of the KYC service (defaults to `127.0.0.1`).
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies; the Windows script now invokes `tools\\log_create_win.cmd` to create log directories.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
-- Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; it now records service URLs and API keys in `.env`, invokes `tools\\log_create_win.cmd` at startup, installs UI dependencies and builds the frontend. The script rolls back on any failure by dropping the database, uninstalling dependencies and stopping containers while logging errors to `logs\setup_full.log`. Use `--silent` to accept defaults, `--config <file>` to supply answers, or `--seed` to execute SQL seed files without prompting. All output is logged to `logs\setup_full.log`. Use `remove_full.cmd` with the same flags to uninstall, remove the environment, drop the database, purge these credentials, delete UI `node_modules` and `.next` directories, and stop and remove the TimescaleDB container.
+- Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; it now records service URLs and API keys in `.env`, invokes `tools\\log_create_win.cmd` at startup, installs UI dependencies and builds the frontend. The script rolls back on any failure by dropping the database, uninstalling dependencies and stopping containers while logging errors to `logs\setup_full.log`. Use `--silent` to accept defaults, `--config <file>` to supply answers, or `--seed` to execute SQL seed files without prompting. All output is logged to `logs\setup_full.log`. Use `remove_full.cmd` with the same flags to uninstall, remove the environment, drop the database, purge these credentials, delete UI `node_modules` and `.next` directories, and stop and remove the TimescaleDB container. Both scripts now capture the database password via a PowerShell secure prompt that hides the input.
 - After base migrations, `setup_full.cmd` applies warehouse schema migrations from `db/migrations/warehouse/*.sql`.
 - After migrations, `setup_full.cmd` can optionally execute seed SQL files from `db/seeds/*.sql` (admin user, demo accounts) to populate sample data.
 - The script then verifies the database schema with `php admin\\db_check.php` and aborts if inconsistencies are found.


### PR DESCRIPTION
## Summary
- replace `set /p DB_PASS` with a PowerShell secure prompt in Windows setup and removal scripts
- document secure password input and bump versions across scripts and docs
- note secure credential handling in changelogs

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6677c6e90832c88ac730d6d72f7c7