### PR TITLE
feat: backup database before migrations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.83
+# Changelog v0.6.84
 =======
 
 
@@ -274,3 +274,4 @@
 - `remove_full.cmd` stops and removes this TimescaleDB container during cleanup.
 - Documented container usage in the user manual and bumped script and documentation versions.
 - Replaced plaintext database password prompts with a PowerShell secure input in `setup_full.cmd` and `remove_full.cmd`.
+- `setup_full.cmd` now dumps the existing database to `backups/` before applying migrations.

--- a/changelog_2025-08-21.md
+++ b/changelog_2025-08-21.md
@@ -1,9 +1,10 @@
-# Changelog v0.6.83
+# Changelog v0.6.84
 
 ## 2025-08-21
 - `setup_full.cmd` now detects missing `psql` or TimescaleDB and launches a `timescale/timescaledb` container with the provided credentials.
 - `remove_full.cmd` stops and removes this TimescaleDB container during cleanup.
 - Documented container usage in the user manual and bumped script and documentation versions.
 - Replaced plaintext database password prompts with a PowerShell secure input in `setup_full.cmd` and `remove_full.cmd`.
+- `setup_full.cmd` now dumps the existing database to `backups/` before applying migrations.
 - Setup scripts now wait for Docker containers to become healthy and roll back on failure.
 - `setup_full.cmd` now ensures the database role exists and grants it privileges on the target database; `admin/db_check.php` verifies the role and permissions.

--- a/setup_full.cmd
+++ b/setup_full.cmd
@@ -1,5 +1,5 @@
 @echo off
-rem setup_full.cmd v0.1.18 (2025-08-21)
+rem setup_full.cmd v0.1.19 (2025-08-21)
 
 if not exist logs mkdir logs
 set LOG_FILE=logs\setup_full.log
@@ -162,6 +162,8 @@ set PGPASSWORD=
 %PSQL_CMD% -h %DB_HOST% -p %DB_PORT% -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE %DB_NAME% TO %DB_USER%;"
 set PGPASSWORD=%DB_PASS%
 %PSQL_CMD% -h %DB_HOST% -p %DB_PORT% -U %DB_USER% -d %DB_NAME% -c "CREATE EXTENSION IF NOT EXISTS timescaledb;"
+mkdir "%~dp0backups" 2>nul
+pg_dump -h %DB_HOST% -p %DB_PORT% -U %DB_USER% %DB_NAME% > backups\%DB_NAME%_%DATE:~-4%%DATE:~4,2%%DATE:~7,2%.sql
 for %%f in (db\migrations\*.sql) do (
   echo Applying %%f
   %PSQL_CMD% -h %DB_HOST% -p %DB_PORT% -U %DB_USER% -d %DB_NAME% -f %%f

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.84
+# User Manual v0.6.85
 =======
 
 
@@ -16,7 +16,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
   - PostgreSQL `psql`
   - Docker
   - Node.js
-- `setup_full.cmd` checks for these tools, prompts for database, RabbitMQ, API Gateway and API keys, writing values to `.env`, and opens download pages if any are missing. If `psql` or TimescaleDB is unavailable, it pulls and starts a `timescale/timescaledb` container with your credentials. The script writes all output to `logs\\setup_full.log` and accepts a `--silent` flag or `--config <file>` to skip prompts. After prompts it creates `.env` if missing, replaces database placeholders with the provided values, creates the database role if needed and grants it privileges on the target database.
+- `setup_full.cmd` checks for these tools, prompts for database, RabbitMQ, API Gateway and API keys, writing values to `.env`, and opens download pages if any are missing. If `psql` or TimescaleDB is unavailable, it pulls and starts a `timescale/timescaledb` container with your credentials. Before applying migrations it dumps the current database to `backups/`. The script writes all output to `logs\\setup_full.log` and accepts a `--silent` flag or `--config <file>` to skip prompts. After prompts it creates `.env` if missing, replaces database placeholders with the provided values, creates the database role if needed and grants it privileges on the target database.
 - Copy `.env.example` to `.env` and adjust values as needed, including `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, `RATE_LIMIT_PER_MINUTE`, `ALPHA_VANTAGE_KEY`, `BINANCE_API_KEY`, `BINANCE_API_SECRET`, `IBKR_API_KEY` and `FRED_API_KEY`.
 - `DB_SCHEMA_VERSION` records the expected database schema revision (`v0.1.7`) checked by `admin/db_check.php`.
 - Configure OAuth token endpoints via `GOOGLE_TOKEN_URL` and `GITHUB_TOKEN_URL` if overriding defaults.

--- a/user_manual_2025-08-21.md
+++ b/user_manual_2025-08-21.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.84
+# User Manual v0.6.85
 =======
 
 
@@ -16,7 +16,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
   - PostgreSQL `psql`
   - Docker
   - Node.js
-- `setup_full.cmd` checks for these tools, prompts for database, RabbitMQ, API Gateway and API keys, writing values to `.env`, and opens download pages if any are missing. If `psql` or TimescaleDB is unavailable, it pulls and starts a `timescale/timescaledb` container with your credentials. The script writes all output to `logs\\setup_full.log` and accepts a `--silent` flag or `--config <file>` to skip prompts. After prompts it creates `.env` if missing, replaces database placeholders with the provided values, creates the database role if needed and grants it privileges on the target database.
+- `setup_full.cmd` checks for these tools, prompts for database, RabbitMQ, API Gateway and API keys, writing values to `.env`, and opens download pages if any are missing. If `psql` or TimescaleDB is unavailable, it pulls and starts a `timescale/timescaledb` container with your credentials. Before applying migrations it dumps the current database to `backups/`. The script writes all output to `logs\\setup_full.log` and accepts a `--silent` flag or `--config <file>` to skip prompts. After prompts it creates `.env` if missing, replaces database placeholders with the provided values, creates the database role if needed and grants it privileges on the target database.
 - Copy `.env.example` to `.env` and adjust values as needed, including `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, `RATE_LIMIT_PER_MINUTE`, `ALPHA_VANTAGE_KEY`, `BINANCE_API_KEY`, `BINANCE_API_SECRET`, `IBKR_API_KEY` and `FRED_API_KEY`.
 - `DB_SCHEMA_VERSION` records the expected database schema revision (`v0.1.7`) checked by `admin/db_check.php`.
 - Configure OAuth token endpoints via `GOOGLE_TOKEN_URL` and `GITHUB_TOKEN_URL` if overriding defaults.


### PR DESCRIPTION
## Summary
- backup the database to `backups/` before migrations in `setup_full.cmd`
- document new backup step and bump versions

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a66b8cf9f4832caeb2e5b79d14201d