### PR TITLE
feat: require admin privileges for setup script

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.85
+# Changelog v0.6.86
 =======
 
 
@@ -43,6 +43,7 @@
 - Setup script automatically installs missing prerequisites via Chocolatey with explanatory messages.
 - `remove_full.cmd` now uninstalls Python, pip, PostgreSQL, Docker Desktop and Node.js.
 - Bumped `setup_full.cmd` to v0.1.20 and `remove_full.cmd` to v0.1.11 with documentation updates.
+- `setup_full.cmd` now checks for administrator privileges and exits if not run as administrator.
 - Setup scripts now wait for Docker containers to become healthy and roll back on failure.
 - Added Dockerfiles for all services with version headers.
 - Introduced root docker-compose.yml wiring services, database, cache and message bus.

--- a/setup_full.cmd
+++ b/setup_full.cmd
@@ -1,5 +1,7 @@
 @echo off
-rem setup_full.cmd v0.1.20 (2025-08-21)
+rem setup_full.cmd v0.1.21 (2025-08-21)
+
+net session >nul 2>&1 || (echo Please run as administrator & exit /b 1)
 
 if not exist logs mkdir logs
 set LOG_FILE=logs\setup_full.log

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.86
+# User Manual v0.6.87
 =======
 
 
@@ -23,7 +23,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Set `KYC_HOST` to control the bind address of the KYC service (defaults to `127.0.0.1`).
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies; the Windows script now invokes `tools\\log_create_win.cmd` to create log directories.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
-- Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; it now records service URLs and API keys in `.env`, invokes `tools\\log_create_win.cmd` at startup, installs UI dependencies and builds the frontend. The script rolls back on any failure by dropping the database, uninstalling dependencies and stopping containers while logging errors to `logs\setup_full.log`. Use `--silent` to accept defaults, `--config <file>` to supply answers, or `--seed` to execute SQL seed files without prompting. All output is logged to `logs\setup_full.log`. Use `remove_full.cmd` with the same flags to uninstall, remove the environment, drop the database, purge these credentials, delete UI `node_modules` and `.next` directories, stop and remove the TimescaleDB container, and uninstall Python, pip, PostgreSQL, Docker Desktop and Node.js via Chocolatey. Both scripts now capture the database password via a PowerShell secure prompt that hides the input.
+- Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; run it with administrator privileges. It now records service URLs and API keys in `.env`, invokes `tools\\log_create_win.cmd` at startup, installs UI dependencies and builds the frontend. The script rolls back on any failure by dropping the database, uninstalling dependencies and stopping containers while logging errors to `logs\setup_full.log`. Use `--silent` to accept defaults, `--config <file>` to supply answers, or `--seed` to execute SQL seed files without prompting. All output is logged to `logs\setup_full.log`. Use `remove_full.cmd` with the same flags to uninstall, remove the environment, drop the database, purge these credentials, delete UI `node_modules` and `.next` directories, stop and remove the TimescaleDB container, and uninstall Python, pip, PostgreSQL, Docker Desktop and Node.js via Chocolatey. Both scripts now capture the database password via a PowerShell secure prompt that hides the input.
 - After base migrations, `setup_full.cmd` applies warehouse schema migrations from `db/migrations/warehouse/*.sql`.
 - After migrations, `setup_full.cmd` can optionally execute seed SQL files from `db/seeds/*.sql` (admin user, demo accounts) to populate sample data.
 - The script then verifies the database schema with `php admin\\db_check.php` and aborts if inconsistencies are found.


### PR DESCRIPTION
## Summary
- ensure setup_full.cmd aborts if not run with admin rights
- document admin requirement in user manual
- log setup change in changelog

## Testing
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_68a6f0c017b0832c87f0c0bb29f7aab1