### PR TITLE
Init setup logging at startup

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.90
+# Changelog v0.6.91
 =======
 
 
@@ -135,6 +135,7 @@
 - Reconciled `development_tasks` with dated logs, adding deliverables for feasibility calculator documentation and backtester benchmarking.
 - Updated user manuals with notes on feasibility calculator integration and backtester performance plans.
 - Replaced `set /p` database password prompts in Windows setup scripts with a PowerShell secure prompt.
+- `setup_full.cmd` now runs `tools\\log_create_win.cmd` at startup and logs to `logs/setup/setup_full.log`; log creation scripts and user manual updated.
 
 ## 2025-08-18
 - Added initial development tasks outline.

--- a/setup_full.cmd
+++ b/setup_full.cmd
@@ -1,11 +1,11 @@
 @echo off
-rem setup_full.cmd v0.1.24 (2025-08-21)
+rem setup_full.cmd v0.1.25 (2025-08-21)
 
 echo Checking for administrator privileges...
 net session >nul 2>&1 || (echo Administrator privileges required. Please run as administrator & exit /b 1)
 
-if not exist logs mkdir logs
-set LOG_FILE=logs\setup_full.log
+call tools\log_create_win.cmd
+set LOG_FILE=logs\setup\setup_full.log
 call :main %* > "%LOG_FILE%" 2>&1
 exit /b %ERRORLEVEL%
 
@@ -13,7 +13,6 @@ exit /b %ERRORLEVEL%
 setlocal
 set "EXIT_CODE=0"
 set "ERROR_MSG="
-call tools\log_create_win.cmd
 
 set "SILENT=0"
 set "CONFIG_FILE="

--- a/tools/log_create.sh
+++ b/tools/log_create.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
-# log directory creator v0.6.36 (2025-08-20)
+# log directory creator v0.6.37 (2025-08-21)
 set -e
 mkdir -p logs
+mkdir -p logs/setup
 mkdir -p logs/containers
 mkdir -p logs/analytics
 mkdir -p backtester/reports
@@ -30,7 +31,7 @@ mkdir -p logs/whatif-service
 mkdir -p reports
 touch reports/.gitkeep
 touch logs/auth.log
-touch logs/setup_full.log
+touch logs/setup/setup_full.log
 touch logs/orchestrator.log
 touch logs/data-ingestion.log
 touch logs/strategy-engine.log

--- a/tools/log_create_win.cmd
+++ b/tools/log_create_win.cmd
@@ -1,6 +1,7 @@
 @echo off
-REM log directory creator v0.6.36 (2025-08-20)
+REM log directory creator v0.6.37 (2025-08-21)
 mkdir logs 2>nul
+mkdir logs\setup 2>nul
 mkdir logs\containers 2>nul
 mkdir logs\analytics 2>nul
 mkdir backtester\reports 2>nul
@@ -29,7 +30,7 @@ mkdir logs\whatif-service 2>nul
 mkdir reports 2>nul
 type nul > reports\.gitkeep
 type nul > logs\auth.log
-type nul > logs\setup_full.log
+type nul > logs\setup\setup_full.log
 type nul > logs\orchestrator.log
 type nul > logs\data-ingestion.log
 type nul > logs\strategy-engine.log

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,8 +1,8 @@
-# User Manual v0.6.92
+# User Manual v0.6.93
 =======
 
 
-Date: 2025-08-22
+Date: 2025-08-21
 
 This document will evolve into a comprehensive encyclopedia for the project.
 
@@ -19,14 +19,14 @@ This document will evolve into a comprehensive encyclopedia for the project.
   - Node.js and npm
   - PostgreSQL `psql` and `pg_dump`
   - Docker
-- `setup_full.cmd` verifies administrator privileges with `net session >nul 2>&1`, checks for these tools with `where`, installs any missing ones via Chocolatey or aborts with guidance, then prompts for database, RabbitMQ, API Gateway and API keys, writing values to `.env` (including `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASS` and `DB_SCHEMA_VERSION`). If `psql` or TimescaleDB is unavailable, it pulls and starts a `timescale/timescaledb` container with your credentials. Before applying migrations it dumps the current database to `backups/`. The script writes all output to `logs\\setup_full.log` and accepts a `--silent` flag or `--config <file>` to skip prompts. After prompts it creates `.env` if missing, replaces database placeholders with the provided values, creates the database role if needed and grants it privileges on the target database.
+- `setup_full.cmd` verifies administrator privileges with `net session >nul 2>&1`, checks for these tools with `where`, installs any missing ones via Chocolatey or aborts with guidance, then prompts for database, RabbitMQ, API Gateway and API keys, writing values to `.env` (including `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASS` and `DB_SCHEMA_VERSION`). If `psql` or TimescaleDB is unavailable, it pulls and starts a `timescale/timescaledb` container with your credentials. Before applying migrations it dumps the current database to `backups/`. The script writes all output to `logs\setup\setup_full.log` and accepts a `--silent` flag or `--config <file>` to skip prompts. After prompts it creates `.env` if missing, replaces database placeholders with the provided values, creates the database role if needed and grants it privileges on the target database.
 - Copy `.env.example` to `.env` and adjust values as needed, including `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB`, `RATE_LIMIT_PER_MINUTE`, `ALPHA_VANTAGE_KEY`, `BINANCE_API_KEY`, `BINANCE_API_SECRET`, `IBKR_API_KEY` and `FRED_API_KEY`.
 - `DB_SCHEMA_VERSION` records the expected database schema revision (`v0.1.7`) checked by `admin/db_check.php`.
 - Configure OAuth token endpoints via `GOOGLE_TOKEN_URL` and `GITHUB_TOKEN_URL` if overriding defaults.
 - Set `KYC_HOST` to control the bind address of the KYC service (defaults to `127.0.0.1`).
 - Run `./setup_env.sh` (Linux/Mac) or `setup_env.cmd` (Windows) to install Python dependencies; the Windows script now invokes `tools\\log_create_win.cmd` to create log directories.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
-- Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; run it with administrator privileges. It now records service URLs and API keys in `.env`, invokes `tools\\log_create_win.cmd` at startup, installs UI dependencies and builds the frontend. The script rolls back on any failure by dropping the database, uninstalling dependencies and stopping containers while logging errors to `logs\setup_full.log`. Use `--silent` to accept defaults, `--config <file>` to supply answers, or `--seed` to execute SQL seed files without prompting. All output is logged to `logs\setup_full.log`. Use `remove_full.cmd` with the same flags to uninstall, remove the virtual environment directory, drop the database, purge these credentials, restore `.env` from `.env.example`, delete UI `node_modules` and `.next` directories, stop and remove the TimescaleDB container, and uninstall Python, pip, PostgreSQL, Docker Desktop and Node.js via Chocolatey. Both scripts capture the database password with a PowerShell `Read-Host -AsSecureString` prompt instead of `set /p`, hiding the input.
+- Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; run it with administrator privileges. It now records service URLs and API keys in `.env`, invokes `tools\\log_create_win.cmd` at startup, installs UI dependencies and builds the frontend. The script rolls back on any failure by dropping the database, uninstalling dependencies and stopping containers while logging errors to `logs\setup\setup_full.log`. Use `--silent` to accept defaults, `--config <file>` to supply answers, or `--seed` to execute SQL seed files without prompting. All output is logged to `logs\setup\setup_full.log`. Use `remove_full.cmd` with the same flags to uninstall, remove the virtual environment directory, drop the database, purge these credentials, restore `.env` from `.env.example`, delete UI `node_modules` and `.next` directories, stop and remove the TimescaleDB container, and uninstall Python, pip, PostgreSQL, Docker Desktop and Node.js via Chocolatey. Both scripts capture the database password with a PowerShell `Read-Host -AsSecureString` prompt instead of `set /p`, hiding the input.
 - After base migrations, `setup_full.cmd` applies warehouse schema migrations from `db/migrations/warehouse/*.sql`.
 - After migrations, `setup_full.cmd` can optionally execute seed SQL files from `db/seeds/*.sql` (admin user, demo accounts) to populate sample data.
 - The script then verifies the database schema with `php admin\\db_check.php` and aborts if inconsistencies are found.


### PR DESCRIPTION
## Summary
- call `tools\log_create_win.cmd` at the start of `setup_full.cmd`
- add `logs/setup` path in log creation scripts
- document new setup log location and update changelog

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a702d4220c832caf3a5896ccace171