### PR TITLE
Run db_check after migrations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.92
+# Changelog v0.6.93
 =======
 
 
@@ -287,6 +287,7 @@
 
 ## 2025-08-22
 - `install_db.sh` now applies warehouse schema migrations from `db/migrations/warehouse/*.sql` after core migrations.
+- `install_db.sh` now runs `php admin\db_check.php` after migrations and aborts on failure.
 - Updated script versions and user manual for warehouse migration support.
 - `setup_full.cmd` now runs `npm install` then `npm run build` within the `ui` directory to build the frontend.
 - `remove_full.cmd` now cleans up `ui\\node_modules` and `ui\\.next` during teardown.

--- a/changelog_2025-08-22.md
+++ b/changelog_2025-08-22.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.92
+# Changelog v0.6.93
 =======
 
 
@@ -286,6 +286,7 @@
 
 ## 2025-08-22
 - `install_db.sh` now applies warehouse schema migrations from `db/migrations/warehouse/*.sql` after core migrations.
+- `install_db.sh` now runs `php admin\db_check.php` after migrations and aborts on failure.
 - Updated script versions and user manual for warehouse migration support.
 - `setup_full.cmd` now runs `npm install` then `npm run build` within the `ui` directory to build the frontend.
 - `remove_full.cmd` now cleans up `ui\\node_modules` and `ui\\.next` during teardown.

--- a/install_db.sh
+++ b/install_db.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# install_db.sh v0.1.2 (2025-08-22)
+# install_db.sh v0.1.3 (2025-08-22)
 set -e
 psql "$@" -c "CREATE EXTENSION IF NOT EXISTS timescaledb;"
 for file in db/migrations/*.sql; do
@@ -10,3 +10,5 @@ for file in db/migrations/warehouse/*.sql; do
   echo "Applying $file"
   psql "$@" -f "$file"
 done
+
+php admin/db_check.php

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.94
+# User Manual v0.6.95
 =======
 
 
@@ -39,7 +39,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Install RabbitMQ with `./install_rabbitmq.sh` and remove it with `./remove_rabbitmq.sh`.
 - Start all services with `docker-compose up -d` and stop them with `docker-compose down`.
 - Setup scripts wait for Docker containers to report healthy status and roll back if any container fails.
-- Run `./install_db.sh` to apply core migrations and then warehouse migrations from `db/migrations/warehouse/*.sql`; the script enables TimescaleDB and converts `prices` to a hypertable.
+- Run `./install_db.sh` to apply core migrations and then warehouse migrations from `db/migrations/warehouse/*.sql`; the script enables TimescaleDB, converts `prices` to a hypertable, and runs `php admin\db_check.php` to validate the schema, aborting on any failure.
 - Create PostgreSQL dumps with `tools/db_backup.sh --retention <days>` (default 7) which stores files under `backups/` and prunes old ones.
 - Restore a dump via `tools/db_restore.sh <dump_file>`.
 - `npm test` now runs without legacy proxy warnings thanks to a local `.npmrc`.

--- a/user_manual_2025-08-22.md
+++ b/user_manual_2025-08-22.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.94
+# User Manual v0.6.95
 =======
 
 
@@ -39,7 +39,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Install RabbitMQ with `./install_rabbitmq.sh` and remove it with `./remove_rabbitmq.sh`.
 - Start all services with `docker-compose up -d` and stop them with `docker-compose down`.
 - Setup scripts wait for Docker containers to report healthy status and roll back if any container fails.
-- Run `./install_db.sh` to apply core migrations and then warehouse migrations from `db/migrations/warehouse/*.sql`; the script enables TimescaleDB and converts `prices` to a hypertable.
+- Run `./install_db.sh` to apply core migrations and then warehouse migrations from `db/migrations/warehouse/*.sql`; the script enables TimescaleDB, converts `prices` to a hypertable, and runs `php admin\db_check.php` to validate the schema, aborting on any failure.
 - Create PostgreSQL dumps with `tools/db_backup.sh --retention <days>` (default 7) which stores files under `backups/` and prunes old ones.
 - Restore a dump via `tools/db_restore.sh <dump_file>`.
 - `npm test` now runs without legacy proxy warnings thanks to a local `.npmrc`.


### PR DESCRIPTION
## Summary
- Run `php admin/db_check.php` after database migrations in `install_db.sh`
- Document schema verification and bump versions in manual and changelog
- Sync dated manual and changelog snapshots

## Testing
- `bash install_db.sh` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed)*
- `php admin/db_check.php` *(fails: connection refused)*
- `npm test` *(fails: Missing script: "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a707c59868832cba3abbb9a6522fbd