### PR TITLE
feat: add database seeds

### DIFF
--- a/admin/db_check.php
+++ b/admin/db_check.php
@@ -1,5 +1,5 @@
 <?php
-// db_check.php v0.1.22 (2025-08-21)
+// db_check.php v0.1.23 (2025-08-22)
 $expectedVersion = 'v0.1.7';
 $dbname = getenv('DB_NAME') ?: 'cashmachiine';
 $dsn = sprintf('pgsql:host=%s;port=%s;dbname=%s',
@@ -210,11 +210,13 @@ $cols = $stmt->fetchAll(PDO::FETCH_COLUMN);
       echo "Missing demo data in demo_accounts\n";
       exit(1);
   }
-  $adminCount = $pdo->query("SELECT COUNT(*) FROM users WHERE role='admin'")->fetchColumn();
-  if ($adminCount == 0) {
-      echo "Missing admin user\n";
-      exit(1);
-  }
+    $adminEmail = 'admin@cashmachiine.local';
+    $adminStmt = $pdo->prepare("SELECT COUNT(*) FROM users WHERE email=? AND role='admin'");
+    $adminStmt->execute([$adminEmail]);
+    if ($adminStmt->fetchColumn() == 0) {
+        echo "Missing admin user: $adminEmail\n";
+        exit(1);
+    }
   $schemaVersion = getenv('DB_SCHEMA_VERSION') ?: 'unknown';
 if ($schemaVersion !== $expectedVersion) {
     echo "Schema version mismatch: expected $expectedVersion, got $schemaVersion\n";

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Changelog v0.6.93
+# Changelog v0.6.94
 =======
 
 
@@ -291,3 +291,4 @@
 - Updated script versions and user manual for warehouse migration support.
 - `setup_full.cmd` now runs `npm install` then `npm run build` within the `ui` directory to build the frontend.
 - `remove_full.cmd` now cleans up `ui\\node_modules` and `ui\\.next` during teardown.
+- Renamed seed SQL files for admin and demo data to 2025-08-22 versions and improved admin verification; setup_full.cmd usage updated and optional seeding documented.

--- a/db/seeds/000_demo_users_2025-08-22.sql
+++ b/db/seeds/000_demo_users_2025-08-22.sql
@@ -1,4 +1,4 @@
--- demo_users.sql v0.1.0 (2025-02-14)
+-- 000_demo_users_2025-08-22.sql v0.1.1 (2025-08-22)
 CREATE TABLE IF NOT EXISTS demo_users (
     id SERIAL PRIMARY KEY,
     email TEXT NOT NULL UNIQUE,

--- a/db/seeds/001_admin_user_2025-08-22.sql
+++ b/db/seeds/001_admin_user_2025-08-22.sql
@@ -1,4 +1,4 @@
--- 001_admin_user_2025-08-20.sql v0.1.0 (2025-08-20)
+-- 001_admin_user_2025-08-22.sql v0.1.1 (2025-08-22)
 INSERT INTO users (email, password, role, created_at)
 VALUES ('admin@cashmachiine.local', 'admin', 'admin', NOW())
 ON CONFLICT (email) DO NOTHING;

--- a/db/seeds/002_demo_data_2025-08-22.sql
+++ b/db/seeds/002_demo_data_2025-08-22.sql
@@ -1,4 +1,4 @@
--- 002_demo_data_2025-08-20.sql v0.1.0 (2025-08-20)
+-- 002_demo_data_2025-08-22.sql v0.1.1 (2025-08-22)
 CREATE TABLE IF NOT EXISTS demo_accounts (
     id SERIAL PRIMARY KEY,
     user_email TEXT NOT NULL,

--- a/setup_full.cmd
+++ b/setup_full.cmd
@@ -1,5 +1,6 @@
 @echo off
-rem setup_full.cmd v0.1.26 (2025-08-22)
+rem setup_full.cmd v0.1.27 (2025-08-22)
+rem Usage: setup_full.cmd [--silent] [--config <file>] [--seed]
 
 echo Checking for administrator privileges...
 net session >nul 2>&1 || (echo Administrator privileges required. Please run as administrator & exit /b 1)

--- a/user_manual.md
+++ b/user_manual.md
@@ -1,4 +1,4 @@
-# User Manual v0.6.95
+# User Manual v0.6.96
 =======
 
 
@@ -28,7 +28,7 @@ This document will evolve into a comprehensive encyclopedia for the project.
 - Use `./remove_env.sh` or `remove_env.cmd` to uninstall these dependencies.
 - Run `setup_full.cmd` for an interactive Windows setup including database creation and a Python virtual environment; run it with administrator privileges. It now records service URLs and API keys in `.env`, invokes `tools\\log_create_win.cmd` at startup, runs `npm install` then `npm run build` within `ui` to build the frontend. The script rolls back on any failure by dropping the database, uninstalling dependencies and stopping containers while logging errors to `logs\setup\setup_full.log`. Use `--silent` to accept defaults, `--config <file>` to supply answers, or `--seed` to execute SQL seed files without prompting. All output is logged to `logs\setup\setup_full.log`. Use `remove_full.cmd` with the same flags to uninstall, remove the virtual environment directory, drop the database, purge these credentials, restore `.env` from `.env.example`, delete UI `node_modules` and `.next` directories, stop and remove the TimescaleDB container, and uninstall Python, pip, PostgreSQL, Docker Desktop and Node.js via Chocolatey. Both scripts capture the database password with a PowerShell `Read-Host -AsSecureString` prompt instead of `set /p`, hiding the input.
 - After base migrations, `setup_full.cmd` applies warehouse schema migrations from `db/migrations/warehouse/*.sql`.
-- After migrations, `setup_full.cmd` can optionally execute seed SQL files from `db/seeds/*.sql` (admin user, demo accounts) to populate sample data.
+- After migrations, `setup_full.cmd` can optionally execute seed SQL files from `db/seeds/*.sql` (admin user, demo users and demo accounts) to populate sample data.
 - The script then verifies the database schema with `php admin\\db_check.php` and aborts if inconsistencies are found.
 - Each service provides `install.sh` and `remove.sh` scripts.
 - Each service now ships with its own `requirements.txt` for Docker builds.


### PR DESCRIPTION
## Summary
- create dated SQL seed files for admin user and demo data
- document optional `--seed` usage in setup script
- verify seeded admin and demo tables during database check

## Testing
- `php -l admin/db_check.php`
- `npm test` *(fails: Missing script "test")*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a70a1072d8832c9dc96460b1b80c0c